### PR TITLE
Tests for file I/O

### DIFF
--- a/config.h
+++ b/config.h
@@ -25,7 +25,7 @@
  * This must end with a slash!
  */
 
-#define TOS_BASE_PATH "/home/changeme/tos/"
+#define TOS_BASE_PATH "./"
 
 /* Enable and disable detailed tracing for the various sub-systems of tosemu */
 /* #define ENABLE_GEMDOS_TRACE */

--- a/gemdosfile.c
+++ b/gemdosfile.c
@@ -242,9 +242,11 @@ static int path_from_tos(char *tp, char *up)
     /* Make canonical */ /* TODO, this limits the usage of symbolic links when mixing the TOS and host file systems */
     realpath(up, tbuf);
     
+#if 0 /* Temporarily disabled? */
     /* Ensure within prefix */    
     if (strncmp(up, tbuf, strlen(TOS_BASE_PATH)-1))
         return 0;
+#endif
     
     return strlen(up);
 }

--- a/gemdosfile.c
+++ b/gemdosfile.c
@@ -544,8 +544,9 @@ uint32_t GEMDOS_Fopen()
     for (i = 0; i < HANDLES; i++)
     {
         if (handles[i].flags & HANDLE_ALLOCATED)
-	    continue;
-	h = i;
+            continue;
+        h = i;
+        break;
     }
 
     if (h == -1)
@@ -564,6 +565,7 @@ uint32_t GEMDOS_Fclose()
     if (!(handles[h].flags & HANDLE_ALLOCATED))
         return GEMDOS_EIHNDL;
 
+    handles[h].flags = 0;
     fclose(handles[h].f);
     return GEMDOS_E_OK;
 }

--- a/gemdosfile.c
+++ b/gemdosfile.c
@@ -562,6 +562,9 @@ uint32_t GEMDOS_Fclose()
 {
     uint16_t h = peek_u16(2);
 
+    if (h >= HANDLES)
+        return GEMDOS_EIHNDL;
+
     if (!(handles[h].flags & HANDLE_ALLOCATED))
         return GEMDOS_EIHNDL;
 

--- a/tests/Fclose.s
+++ b/tests/Fclose.s
@@ -1,0 +1,63 @@
+| TOSEMU - an emulated environment for TOS applications
+| Copyright (C) 2014 Johan Thelin <e8johan@gmail.com>
+| 
+| This program is free software; you can redistribute it and/or
+| modify it under the terms of the GNU General Public License
+| as published by the Free Software Foundation; either version 2
+| of the License, or (at your option) any later version.
+|
+| This program is distributed in the hope that it will be useful,
+| but WITHOUT ANY WARRANTY; without even the implied warranty of
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+| GNU General Public License for more details.
+|
+| You should have received a copy of the GNU General Public License
+| along with this program; if not, write to the Free Software
+| Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+XDEF _start
+
+.text
+_start:
+        move.w  #0,-(sp)        | read-only
+        pea     fname1
+        move.w  #61,-(sp)       | call Fopen
+        trap    #1
+        addq.l  #8,sp
+        
+        tst.w   d0              | check success
+        bmi.s   fail
+        
+        move.w  d0,d7
+        move.w  d0,-(sp)
+        move.w  #62,-(sp)       | call Fclose
+        trap    #1
+        addq.l  #4,sp
+        
+        tst.w   d0              | check success
+        bmi.s   fail
+        
+        move.w  d7,-(sp)
+        move.w  #62,-(sp)       | call Fclose
+        trap    #1
+        addq.l  #4,sp
+        
+        tst.w   d0              | check failure
+        bpl.s   fail
+        
+        move.w  #-42,-(sp)
+        move.w  #62,-(sp)       | call Fclose
+        trap    #1
+        addq.l  #4,sp
+        
+        tst.w   d0              | check failure
+        bpl.s   fail
+        
+        clr.w   -(sp)           | call Pterm0
+        trap    #1
+        
+fail:   move.w  #1,-(sp)
+        move.w  #0x4c, -(sp)    | call Pterm
+        trap    #1
+
+fname1: .ascii  "Makefile\0"

--- a/tests/Fopen.s
+++ b/tests/Fopen.s
@@ -1,0 +1,48 @@
+| TOSEMU - an emulated environment for TOS applications
+| Copyright (C) 2014 Johan Thelin <e8johan@gmail.com>
+| 
+| This program is free software; you can redistribute it and/or
+| modify it under the terms of the GNU General Public License
+| as published by the Free Software Foundation; either version 2
+| of the License, or (at your option) any later version.
+|
+| This program is distributed in the hope that it will be useful,
+| but WITHOUT ANY WARRANTY; without even the implied warranty of
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+| GNU General Public License for more details.
+|
+| You should have received a copy of the GNU General Public License
+| along with this program; if not, write to the Free Software
+| Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+XDEF _start
+
+.text
+_start:
+        move.w  #0,-(sp)        | read-only
+        pea     fname1
+        move.w  #61,-(sp)       | call Fopen
+        trap    #1
+        addq.l  #8,sp
+        
+        tst.w   d0              | check success
+        bmi.s   fail
+        
+        move.w  #0,-(sp)        | read-only
+        pea     fname2
+        move.w  #61,-(sp)       | call Fopen
+        trap    #1
+        addq.l  #8,sp
+        
+        tst.w   d0              | check failure
+        bpl.s   fail
+        
+        clr.w   -(sp)           | call Pterm0
+        trap    #1
+        
+fail:   move.w  #1,-(sp)
+        move.w  #0x4c,-(sp)     | call Pterm
+        trap    #1
+
+fname1: .ascii  "Makefile\0"
+fname2: .ascii  "not found\0"

--- a/tests/Fread.s
+++ b/tests/Fread.s
@@ -1,0 +1,57 @@
+| TOSEMU - an emulated environment for TOS applications
+| Copyright (C) 2014 Johan Thelin <e8johan@gmail.com>
+| 
+| This program is free software; you can redistribute it and/or
+| modify it under the terms of the GNU General Public License
+| as published by the Free Software Foundation; either version 2
+| of the License, or (at your option) any later version.
+|
+| This program is distributed in the hope that it will be useful,
+| but WITHOUT ANY WARRANTY; without even the implied warranty of
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+| GNU General Public License for more details.
+|
+| You should have received a copy of the GNU General Public License
+| along with this program; if not, write to the Free Software
+| Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+XDEF _start
+
+        .equ bytes,100
+
+.text
+_start:
+        move.w  #0,-(sp)        | read-only
+        pea     fname
+        move.w  #61,-(sp)       | call Fopen
+        trap    #1
+        addq.l  #8,sp
+        
+        tst.w   d0              | check success
+        bmi.s   fail
+        
+        pea     buf
+        move.l  #bytes,-(sp)
+        move.w  d0,-(sp)
+        move.w  #63,-(sp)       | call Fread
+        trap    #1
+        lea     12(sp),sp
+
+        cmp.l   #bytes,d0       | check success
+        bne.s   fail
+        
+        clr.b   buf+bytes
+        pea     buf
+        move.w  #9,-(sp)        | call Cconws
+        trap    #1
+        addq.l   #6,sp
+        
+        clr.w   -(sp)           | call Pterm0
+        trap    #1
+        
+fail:   move.w  #1,-(sp)
+        move.w  #0x4c, -(sp)    | call Pterm
+        trap    #1
+
+fname:  .ascii  "Makefile\0"
+buf:    ds.b    bytes+1

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,6 @@
 # Each testname is build from a source file with the file name extension .s
-STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal c-helloworld
+STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal c-helloworld \
+          Fopen
 
 CC=m68k-atari-mint-gcc
 TOSEMU=../bin/tosemu
@@ -19,6 +20,7 @@ check: all
 	$(TOSEMU) test-Cconout > out && test "`cat out`" = 'Hello World!'
 	$(TOSEMU) test-Cconws > out && test "`cat out`" = 'Hello World!'
 	$(TOSEMU) test-Fstraversal
+	$(TOSEMU) test-Fopen
 	$(TOSEMU) test-c-helloworld
 
 clean:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 # Each testname is build from a source file with the file name extension .s
 STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal c-helloworld \
-          Fopen
+          Fopen Fclose
 
 CC=m68k-atari-mint-gcc
 TOSEMU=../bin/tosemu
@@ -21,6 +21,7 @@ check: all
 	$(TOSEMU) test-Cconws > out && test "`cat out`" = 'Hello World!'
 	$(TOSEMU) test-Fstraversal
 	$(TOSEMU) test-Fopen
+	$(TOSEMU) test-Fclose
 	$(TOSEMU) test-c-helloworld
 
 clean:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 # Each testname is build from a source file with the file name extension .s
 STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal c-helloworld \
-          Fopen Fclose
+          Fopen Fclose Fread
 
 CC=m68k-atari-mint-gcc
 TOSEMU=../bin/tosemu
@@ -22,6 +22,10 @@ check: all
 	$(TOSEMU) test-Fstraversal
 	$(TOSEMU) test-Fopen
 	$(TOSEMU) test-Fclose
+	$(TOSEMU) test-Fread > out
+	head -c100 Makefile >out2
+	cmp out out2
+	rm out2
 	$(TOSEMU) test-c-helloworld
 
 clean:


### PR DESCRIPTION
Add tests for `Fread`, `Fclose`, and `Fread`.  Also implements `Fread`.

**WARNING!**  I didn't know how to handle the TOS file path prefix, so I disabled it.  I guess it should be a configuration or runtime option?

As an unintended side effect, the `Fstraversal` tests starts outputting things.