### PR TITLE
Fixes for Supexec

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 # Each testname is build from a source file with the file name extension .s
 STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal c-helloworld \
-          Fopen Fclose Fread
+          Fopen Fclose Fread Supexec
 
 CC=m68k-atari-mint-gcc
 TOSEMU=../bin/tosemu
@@ -26,6 +26,7 @@ check: all
 	head -c100 Makefile >out2
 	cmp out out2
 	rm out2
+	$(TOSEMU) test-Supexec
 	$(TOSEMU) test-c-helloworld
 
 clean:

--- a/tests/Supexec.s
+++ b/tests/Supexec.s
@@ -1,0 +1,44 @@
+| TOSEMU - an emulated environment for TOS applications
+| Copyright (C) 2014 Johan Thelin <e8johan@gmail.com>
+| 
+| This program is free software; you can redistribute it and/or
+| modify it under the terms of the GNU General Public License
+| as published by the Free Software Foundation; either version 2
+| of the License, or (at your option) any later version.
+|
+| This program is distributed in the hope that it will be useful,
+| but WITHOUT ANY WARRANTY; without even the implied warranty of
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+| GNU General Public License for more details.
+|
+| You should have received a copy of the GNU General Public License
+| along with this program; if not, write to the Free Software
+| Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+XDEF _start
+
+.text
+_start:
+        move.l  sp,a3
+
+        pea     func
+        move.w  #38,-(sp)       | call Supexec
+        trap    #14
+        addq.l  #6,sp
+
+        cmp.l   #42,d0          | check return value
+        bne     fail
+
+        cmp.l   a3,sp           | check a3 not clobbered
+        bne     fail
+
+        clr.w   -(sp)           | call Pterm0
+        trap    #1
+
+fail:   move.w  #1,-(sp)
+        move.w  #0x4c,-(sp)     | call Pterm
+        trap    #1
+        
+func:   move.l  8,a3            | read from protected RAM
+        moveq   #42,d0          | return a value
+        rts

--- a/tossystem.c
+++ b/tossystem.c
@@ -91,7 +91,7 @@ int init_tos_environment(struct tos_environment *te, void *binary, uint64_t size
     
     /* Setup "static" data areas */
     te->staticmem0 = malloc(0x200);       /* 0x0 - 0x1ff */
-    te->staticmem1 = malloc(0x5B4-0x380); /* 0x380 - 0x5B4 */
+    te->staticmem1 = malloc(0x600-0x380); /* 0x380 - 0x5ff */
     
     /* Create supervisor memory for a stack */
     te->supermem = malloc(SUPERMEMSIZE);
@@ -157,7 +157,7 @@ int init_tos_environment(struct tos_environment *te, void *binary, uint64_t size
     reset_memory();
     add_ptr_memory_area("staticmem0", MEMORY_SUPERREAD, 0x0, 0x1ff, te->staticmem0);
     add_fnct_memory_area("magicmem0", MEMORY_SUPERREAD, 0x200, 0x2, 0, magic_xbios_supexec_read, magic_xbios_supexec_write);
-    add_ptr_memory_area("staticmem1", MEMORY_SUPERREAD | MEMORY_SUPERWRITE, 0x380, 0x5B4-0x380, te->staticmem1); /* TODO this will probably have to be read using a custom function */
+    add_ptr_memory_area("staticmem1", MEMORY_SUPERREAD | MEMORY_SUPERWRITE, 0x380, 0x600-0x380, te->staticmem1); /* TODO this will probably have to be read using a custom function */
     add_ptr_memory_area("basepage", MEMORY_READ, 0x800, 0x100, te->bp);
     add_ptr_memory_area("userram", MEMORY_READWRITE, 0x900, te->size, te->appmem);
     add_ptr_memory_area("superram", MEMORY_SUPERREAD | MEMORY_SUPERWRITE, 0x600, SUPERMEMSIZE, te->supermem);


### PR DESCRIPTION
- Extend the `staticmem1` area to 0x600, which is where the supervisor stack starts.
- Make the magic word at 0x200 be a NOP, because it's executed when the Supexec subroutine returns.
- Return D0 from subroutine.
- Save and retsore D3-D7 and A3-A6.
- Add test.