### PR TITLE
Fdelete

### DIFF
--- a/gemdos.c
+++ b/gemdos.c
@@ -178,7 +178,6 @@ uint32_t GEMDOS_Unknown();
 #define GEMDOS_Fchmod NULL
 #define GEMDOS_Fchown NULL
 #define GEMDOS_Fcntl GEMDOS_Unknown
-#define GEMDOS_Fdelete NULL
 #define GEMDOS_Fdup NULL
 #define GEMDOS_Fforce NULL
 #define GEMDOS_Fgetchar NULL

--- a/gemdosfile.c
+++ b/gemdosfile.c
@@ -311,7 +311,7 @@ uint32_t GEMDOS_Dsetpath()
         return GEMDOS_EFILNF;
 
     if (chdir(ubuf))
-      printf("chdir error\n");
+        perror("chdir");
 
     return 0;
 }
@@ -355,6 +355,21 @@ static int get_handle(FILE *f)
     return -1;
 }
 
+static void make_dirs(char *path)
+{
+    char *start, *end;
+
+    start = path;
+    while ((end = strchr(start, '/')) != NULL)
+    {
+        *end = 0;
+        if (mkdir(path, 0777) < 0 && errno != EEXIST)
+            perror("mkdir");
+        *end = '/';
+        start = end + 1;
+    }
+}
+
 uint32_t GEMDOS_Fcreate()
 {
     uint32_t addr = peek_u32(2);
@@ -373,6 +388,7 @@ uint32_t GEMDOS_Fcreate()
     if (!path_from_tos(buf, ubuf))
         return GEMDOS_EFILNF;
 
+    make_dirs(ubuf);
     fd = creat(ubuf, 0777);
     if (fd < 0)
         return GEMDOS_EACCDN;

--- a/gemdosfile.c
+++ b/gemdosfile.c
@@ -339,6 +339,29 @@ uint32_t GEMDOS_Dcreate()
     return 0;
 }
 
+uint32_t GEMDOS_Fdelete()
+{
+    uint32_t addr = peek_u32(2);
+    char buf[PATH_MAX+1];
+    char ubuf[PATH_MAX+1];
+
+    FUNC_TRACE_ENTER_ARGS {
+        printf("    addr: 0x%x\n", addr);
+    }
+
+    memset(buf, 0, PATH_MAX+1);
+    memset(ubuf, 0, PATH_MAX+1);
+    get_path(buf, addr);
+
+    if (!path_from_tos(buf, ubuf))
+        return GEMDOS_EFILNF;
+
+    if (unlink(ubuf) != 0)
+        return GEMDOS_EFILNF;
+
+    return 0;
+}
+
 static struct fhandle handles[HANDLES];
 
 static int get_handle(FILE *f)

--- a/gemdosfile_p.h
+++ b/gemdosfile_p.h
@@ -46,5 +46,6 @@ uint32_t GEMDOS_Dgetpath();
 uint32_t GEMDOS_Dsetpath();
 uint32_t GEMDOS_Dcreate();
 uint32_t GEMDOS_Fcreate();
+uint32_t GEMDOS_Fdelete();
 
 #endif /* GEMDOSFILE_H */

--- a/tests/Fdelete.s
+++ b/tests/Fdelete.s
@@ -1,0 +1,47 @@
+| TOSEMU - an emulated environment for TOS applications
+| Copyright (C) 2014 Johan Thelin <e8johan@gmail.com>
+| 
+| This program is free software; you can redistribute it and/or
+| modify it under the terms of the GNU General Public License
+| as published by the Free Software Foundation; either version 2
+| of the License, or (at your option) any later version.
+|
+| This program is distributed in the hope that it will be useful,
+| but WITHOUT ANY WARRANTY; without even the implied warranty of
+| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+| GNU General Public License for more details.
+|
+| You should have received a copy of the GNU General Public License
+| along with this program; if not, write to the Free Software
+| Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+XDEF _start
+
+.text
+_start:
+        clr.w   -(sp)
+        pea     name
+        move.w  #65,-(sp)       | call Fdelete
+        trap    #1
+        addq.l  #8,sp
+        
+        tst.w   d0              | check success
+        bmi.s   fail
+        
+        clr.w   -(sp)
+        pea     name
+        move.w  #65,-(sp)       | call Fdelete
+        trap    #1
+        addq.l  #8,sp
+        
+        tst.w   d0              | check failure
+        bpl.s   fail
+        
+        clr.w   -(sp)           | call Pterm0
+        trap    #1
+        
+fail:   move.w  #1,-(sp)
+        move.w  #0x4c,-(sp)     | call Pterm
+        trap    #1
+
+name:   .ascii  "FNAME\0"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 # Each testname is build from a source file with the file name extension .s
 STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal c-helloworld \
-          Fopen Fclose Fread Supexec Dcreate Fcreate Fwrite
+          Fopen Fclose Fread Supexec Dcreate Fcreate Fwrite Fdelete
 
 CC=m68k-atari-mint-gcc
 TOSEMU=../bin/tosemu
@@ -33,7 +33,7 @@ check: all
 	$(TOSEMU) test-Fwrite
 	echo -n "hello world" > out
 	cmp FNAME out
-	rm FNAME
+	$(TOSEMU) test-Fdelete
 	$(TOSEMU) test-c-helloworld
 
 clean:


### PR DESCRIPTION
- `Fcreate` also creates subdirectories, e.g. if passed `FOO\BAR\BAZ`.
- Add `Fdelete`.

Now the self-extracting archive [STARTER.TOS](http://umich.edu/~archive/atari/starter.tos) works.  It contains TOS apps for all popular archivers.