### PR TITLE
Dynamic TOS_BASE_PATH

### DIFF
--- a/config.h
+++ b/config.h
@@ -20,13 +20,6 @@
 
 #include <stdio.h>
 
-/* Base path of TOS file system root 
- *
- * This must end with a slash!
- */
-
-#define TOS_BASE_PATH ""
-
 /* Enable and disable detailed tracing for the various sub-systems of tosemu */
 /* #define ENABLE_GEMDOS_TRACE */
 /* #define ENABLE_BIOS_TRACE */

--- a/gemdosfile.c
+++ b/gemdosfile.c
@@ -63,6 +63,8 @@ struct fhandle
 #define HANDLES 10
 #define HANDLE_ALLOCATED 0x001
 
+static struct tos_environment *tos_env;
+
 /* File functions ************************************************************/
 
 uint32_t GEMDOS_Fseek()
@@ -249,7 +251,7 @@ static int path_from_tos(char *tp, char *up)
     memset(tbuf, 0, PATH_MAX+1);
     
     /* Prepend prefix */
-    strncpy(up, TOS_BASE_PATH, PATH_MAX);
+    strncpy(up, tos_env->base_path, PATH_MAX);
     len = strlen(up);
     src = tp;
     dest = up + len;
@@ -284,11 +286,12 @@ static int path_from_tos(char *tp, char *up)
     /* Make canonical */ /* TODO, this limits the usage of symbolic links when mixing the TOS and host file systems */
     realpath(up, tbuf);
     
-#if 0 /* Temporarily disabled? */
-    /* Ensure within prefix */    
-    if (strncmp(up, tbuf, strlen(TOS_BASE_PATH)-1))
-        return 0;
-#endif
+    if (tos_env->base_path[0] != 0)
+    {
+        /* Ensure within prefix */    
+        if (strncmp(up, tbuf, strlen(tos_env->base_path)-1))
+            return 0;
+    }
     
     return strlen(up);
 }
@@ -794,6 +797,8 @@ void gemdos_file_init(struct tos_environment *te)
         handles[i].flags = HANDLE_ALLOCATED;
     handles[0].f = stdin;
     handles[1].f = stdout;
+
+    tos_env = te;
 }
 
 void gemdos_file_free()

--- a/tossystem.c
+++ b/tossystem.c
@@ -81,6 +81,7 @@ int init_tos_environment(struct tos_environment *te, void *binary, uint64_t size
     uint8_t *ptr = 0;
     uint32_t *ptr32 = 0;
     uint32_t adr = 0;
+    char *path;
     
     /* Ensure that binary is large enough to hold a header */
     if (size < sizeof(struct exec_header))
@@ -197,6 +198,22 @@ int init_tos_environment(struct tos_environment *te, void *binary, uint64_t size
                 }
             }
         }
+    }
+
+    path = getenv("TOS_BASE_PATH");
+    if (path == NULL)
+        te->base_path = "";
+    else
+    {
+        int n = strlen(path);
+        te->base_path = malloc(n + 2);
+        if (te->base_path == NULL)
+        {
+            exit(1);
+        }
+        strcpy(te->base_path, path);
+        te->base_path[n] = '/';
+        te->base_path[n+1] = 0;
     }
     
     /* TODO Move into CPU initialization */

--- a/tossystem.h
+++ b/tossystem.h
@@ -38,6 +38,8 @@ struct tos_environment {
              ssize;
 
     struct basepage *bp;
+
+    char *base_path;
 };
 
 int init_tos_environment(struct tos_environment *te, void *binary, uint64_t binary_size);


### PR DESCRIPTION
Use the `TOS_BASE_PATH` environment variable to set the file system prefix.  If there is no such variable, access the file system directly.