### PR TITLE
Supexc

### DIFF
--- a/bios.c
+++ b/bios.c
@@ -165,7 +165,12 @@ void bios_trap()
     for(i=0; i<=sizeof(BIOS_functions)/sizeof(struct BIOS_function); ++i) {
         if (BIOS_functions[i].id == fnct) {
             if (BIOS_functions[i].fnct) {
-                m68k_set_reg(M68K_REG_D0, BIOS_functions[i].fnct());
+                uint32_t r = BIOS_functions[i].fnct();
+#ifdef ENABLE_BIOS_TRACE
+                printf("Return from %s: %d = 0x%x\n",
+                       BIOS_functions[i].name, r, r);
+#endif
+                m68k_set_reg(M68K_REG_D0, r);
             } else {
                 halt_execution();
                 printf("BIOS %s (0x%x) not implemented\n", BIOS_functions[i].name, fnct);

--- a/bios.c
+++ b/bios.c
@@ -32,6 +32,22 @@
 #define BIOS_TRACE_CONTEXT
 #include "config.h"
 
+uint32_t BIOS_Setexc()
+{
+    uint16_t nm = peek_u16(2);
+    uint32_t vec = peek_u32(4);
+    uint32_t old;
+
+    FUNC_TRACE_ENTER_ARGS {
+        printf("    nm: 0x%x, vec: 0x%x\n", nm, vec);
+    }
+
+    old = m68k_read_memory_32(4*nm);
+    m68k_write_memory_32(4*nm, vec);
+
+    return old;
+}
+
 uint32_t BIOS_Bconin()
 {
     uint16_t dev = peek_u16(2);
@@ -115,7 +131,6 @@ uint32_t BIOS_Bcostat()
 #define BIOS_Kbshift NULL
 #define BIOS_Mediach NULL
 #define BIOS_Rwabs NULL
-#define BIOS_Setexc NULL
 #define BIOS_Tickcal NULL
 
 /* BIOS function table according to

--- a/tossystem.c
+++ b/tossystem.c
@@ -175,7 +175,7 @@ int init_tos_environment(struct tos_environment *te, void *binary, uint64_t size
     copy_cmdlin((void *)te->bp->p_cmdlin, argc, argv);
         
     reset_memory();
-    add_ptr_memory_area("staticmem0", MEMORY_SUPERREAD, 0x0, 0x1ff, te->staticmem0);
+    add_ptr_memory_area("staticmem0", MEMORY_READWRITE | MEMORY_SUPERWRITE, 0x0, 0x1ff, te->staticmem0);
     add_fnct_memory_area("magicmem0", MEMORY_SUPERREAD, 0x200, 0x2, 0, magic_xbios_supexec_read, magic_xbios_supexec_write);
     add_ptr_memory_area("staticmem1", MEMORY_SUPERREAD | MEMORY_SUPERWRITE, 0x380, 0x600-0x380, te->staticmem1); /* TODO this will probably have to be read using a custom function */
     add_ptr_memory_area("basepage", MEMORY_READWRITE, 0x800, 0x100, te->bp);


### PR DESCRIPTION
I was trying to run the UNSQUEEG program to decompress some files.  It uses the BIOS Supexc() call to set some exception vectors.  After that it calls `trap #7` to one of those vectors.  I added The Supexc() call.  I didn't quite undestand how to make the "staticmem0" RAM writable for this case, so I just changed it to MEMORY_READWRITE to get past this hurdle.