### PR TITLE
Build: NO_WAYLAND, for a machine with no Wayland to build against

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,7 +11,13 @@ jobs:
             - uses: actions/checkout@v2
               with:
                 submodules: recursive
+            # NO_WAYLAND=1 because a build server has no Wayland to build
+            # against: no headers, no libraries and no wayland-scanner. It
+            # costs nothing that is checked here - the runner has no desktop
+            # either, so the windows would have had nowhere to appear, and the
+            # tests all run with the screen in memory as it is. See the
+            # Makefile for what it leaves out.
             - run: |
                 sh ./install-deps.sh
-                make check
-                make emuvdi-check
+                make NO_WAYLAND=1 check
+                make NO_WAYLAND=1 emuvdi-check

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,27 @@ WAYLANDLIBS = $(shell pkg-config --libs wayland-client xkbcommon)
 # dependency it should not have.
 WAYLANDONLYLIBS = $(shell pkg-config --libs wayland-client)
 
+# Building on a machine that has no Wayland to build against.
+#
+# Wayland is a build dependency here rather than a run time one. The emulator
+# already runs with nobody to show anything to - gfx_open answers that there is
+# no window and the screen stays in memory, which is what happens on a machine
+# where nobody is logged in and what the whole test suite does anyway - but the
+# headers and the libraries still have to be there to compile it at all.
+#
+# NO_WAYLAND=1 leaves them out. What goes with them is the half of gfx.c that
+# opens windows and the question screen.c asks about how large the display is;
+# everything an application can see is the same, because all of that happens in
+# the emulated screen and none of it happens on the desktop. It is meant for a
+# build server, which is a machine with no desktop for the answer to differ on.
+ifdef NO_WAYLAND
+WAYLANDGENERATED =
+WAYLANDHEADERS =
+WAYLANDFLAGS = -DNO_WAYLAND
+WAYLANDLIBS =
+WAYLANDONLYLIBS =
+endif
+
 EMUVDIFILES = emuvdi/hostvars.c emuvdi/hostfs.c emuvdi/fonts.c emuvdi/textblit.c emuvdi/bridge.c \
               emuvdi/gsx2.c emuvdi/gemoblib.c emuvdi/gemobjop.c emuvdi/gemfmalt.c emuvdi/gemmnlib.c emuvdi/vdi_raster.c emuvdi/aeskernel.c \
               emuvdi/strings.c
@@ -261,6 +282,13 @@ gen/xdg-decoration-unstable-v1-client-protocol.h:
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS)/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml $@
 
 gfx.o: $(WAYLANDHEADERS)
+
+# The two files NO_WAYLAND changes, which depend on this one as well as on
+# their source. What the flag decides is what those objects contain rather than
+# merely how they were compiled, and make has no other way to see that turning
+# it on or off has made them stale - the same reason the EmuTOS objects above
+# depend on this file.
+gfx.o screen.o: Makefile
 
 # Every object needs the generated m68kops.h, so none of them may be compiled
 # before m64kmake has run

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,63 @@ emuvdi/%.o: emuvdi/%.c Makefile
 # in the submodule compile to, and there is no other way for make to see that.
 -include $(EMUTOSOBJECTS:.o=.d)
 
+# And a .d that is not there yet is not something to go and make. It is written
+# as a side effect of compiling the object, so on a first build there are none
+# and there is nothing wrong with that.
+#
+# Saying so stops make from looking for a way to build one, which it does by
+# way of the built-in rule that links a program from the object of the same
+# name: emuvdi/obj/vdi/vdi_main.d becomes a hunt for vdi_main.d.o and then for
+# vdi_main.d.c in the submodule, which is not there and never was, so the
+# $(EMUTOS)/%.c rule announces a missing submodule that is present. Thirty-two
+# of those, one for each object, before the build has begun. An empty recipe is
+# what ends the hunt; make ignores the failure, so they were only ever noise,
+# but noise on the first line of the log somebody reads.
+$(EMUTOSOBJECTS:.o=.d): ;
+
+# The parts of EmuTOS that are generated rather than carried.
+#
+# A resource is drawn in a resource editor and kept as a .rsc and a .def, and
+# EmuTOS turns each one into C when it builds rather than keeping the C - its
+# .gitignore says as much. So a fresh checkout of the submodule has the inputs
+# and none of the outputs, and the first source that includes gem_rsc.h stops
+# the build. Three of them are wanted here: the AES's own resource, the mouse
+# forms, and the header the localisation settings come out as.
+#
+# This is what a build server saw and this machine did not. A tree that has
+# ever had them made is a tree where they are simply there, so the dependency
+# was invisible from here and fatal from anywhere else.
+#
+# They are made by EmuTOS's own Makefile rather than by a copy of its rules,
+# which is the same principle as the rest of the port: how the submodule builds
+# is its own business, and emuvdi/ adapts the result. None of the three needs a
+# cross compiler - the tools that write them are built for the host - and all
+# of them are ignored by EmuTOS's git, so making them leaves the submodule as
+# clean as it was found.
+EMUTOSGENERATED = $(EMUTOS)/aes/gem_rsc.c $(EMUTOS)/aes/gem_rsc.h \
+                  $(EMUTOS)/aes/mforms.c $(EMUTOS)/aes/mforms.h \
+                  $(EMUTOS)/include/i18nconf.h
+
+# The '%' where a '.' belongs is EmuTOS's trick, and it is here for their
+# reason: one run of the tool writes both the .c and the .h, and only a pattern
+# rule tells make that one run produces both. Two ordinary rules would be two
+# runs, and with -j two runs at once over the same pair of files.
+$(EMUTOS)/aes/gem_rsc%c $(EMUTOS)/aes/gem_rsc%h: \
+                $(EMUTOS)/aes/gem%rsc $(EMUTOS)/aes/gem%def
+	$(MAKE) -C $(EMUTOS) aes/gem_rsc.c
+
+$(EMUTOS)/aes/mforms%c $(EMUTOS)/aes/mforms%h: \
+                $(EMUTOS)/aes/mform%rsc $(EMUTOS)/aes/mform%def
+	$(MAKE) -C $(EMUTOS) aes/mforms.c
+
+$(EMUTOS)/include/i18nconf.h: $(EMUTOS)/localise.ctl
+	$(MAKE) -C $(EMUTOS) include/i18nconf.h
+
+# Every object built out of the submodule wants all of them there first. The
+# emuvdi/obj/%.o rule names only the source it compiles, and on a first build
+# there are no .d files yet to say which headers that source went on to read.
+$(EMUTOSOBJECTS): $(EMUTOSGENERATED)
+
 # Main emulator target
 bin/tosemu: $(OBJECTS) $(EMUTOSOBJECTS)
 	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ picture of another computer. Set `TOSEMU_NO_WINDOW` to
 keep the screen in memory, which is what the tests do: the emulator runs the
 same either way, and the variable only decides whether anyone can see it.
 
+Showing them needs Wayland, which is a build dependency rather than a run time
+one: `wayland-client`, `xkbcommon` and `wayland-scanner` have to be there to
+compile it at all, even on a machine where nobody will ever be logged in to see
+a window. `make NO_WAYLAND=1` builds without them. What goes is the half of
+`gfx.c` that opens windows and the question `screen.c` asks about how large the
+display is, and what is left answers what the ordinary build already answers
+when there is no compositor to connect to - so the emulator takes the same path
+through the AES, the screen is in memory as it always was, and `make check`
+passes exactly as it does otherwise. It is meant for a build server, which is
+what CI runs on.
+
 Which screen it is comes from `TOSEMU_SCREEN`. The ST's three are `low`,
 320x200 in sixteen colours, `medium`, 640x200 in four, and `high`, 640x400 in
 two; the TT's are `tt-medium`, 640x480 in sixteen, and `tt-high`, 1280x960 in
@@ -492,6 +503,10 @@ anything is committed:
 `make check` builds its tests with the m68k-atari-mint cross compiler and runs
 them inside the emulator, so a failure there is a failure of the thing being
 tested rather than of the test.
+
+None of them needs a compositor. CI passes `NO_WAYLAND=1` because a build
+server has no Wayland to build against, and the tests come out the same: they
+all run with the screen in memory, which is the part being checked.
 
 **The self hosted ones**, which need the period tool chains under `tos_root`:
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ against what it should have drawn; unlike the other tests it builds for the
 host rather than for the emulated machine, because what it is checking is the
 port.
 
+A few of the files it is built from are generated rather than carried: the
+AES's resource and the mouse forms are kept as a `.rsc` and a `.def` and turned
+into C when EmuTOS builds, and the localisation settings come out as a header.
+A fresh checkout has the inputs and none of the outputs, so the build makes
+them by asking EmuTOS's own Makefile for them, with the host compiler and no
+cross tools. EmuTOS ignores all of them in its `.gitignore`, so the submodule
+stays as clean as it was found.
+
 The emulated screen is never shown. It is a coordinate space and a piece of
 memory: GEM lays its windows out in it and draws into it the way it always did.
 What appears on the desktop are the windows themselves - one for each window a

--- a/gfx.c
+++ b/gfx.c
@@ -44,6 +44,12 @@
  * is not a small modern pixel, it is a large old one, and the only honest way
  * to make it large again is to repeat it. A compositor asked to scale would
  * smooth it, which is the one thing it must not do.
+ *
+ * The file is in two halves, and NO_WAYLAND keeps the first. That half is the
+ * queues of keys and clicks, and the input a test asks for on the command line
+ * when there is nobody to press anything - none of which involves a compositor.
+ * The second half is the windows, and a build without Wayland answers there
+ * what this already answers when nobody is logged in. See the Makefile.
  */
 
 /* memfd_create is a GNU extension, and this has to be said before the first
@@ -60,11 +66,13 @@
 #include <poll.h>
 #include <sys/mman.h>
 
+#ifndef NO_WAYLAND
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
 #include "xdg-shell-client-protocol.h"
 #include "xdg-dialog-v1-client-protocol.h"
 #include "xdg-decoration-unstable-v1-client-protocol.h"
+#endif
 
 #include "surface.h"
 #include "screen.h"
@@ -88,6 +96,8 @@ void host_window_closed(int16_t handle);
  * application can honestly be shown at different sizes, and one day they will
  * be.
  */
+
+#ifndef NO_WAYLAND
 
 /*
  * A window, which shows one rectangle of a surface. A GEM window is one of
@@ -144,7 +154,10 @@ struct window {
 #define MENU     (10)
 #define WINDOWS  (11)
 
+#endif /* NO_WAYLAND */
+
 static struct {
+#ifndef NO_WAYLAND
     struct wl_display *display;
     struct wl_registry *registry;
     struct wl_compositor *compositor;
@@ -166,6 +179,7 @@ static struct {
     /* Which window the pointer is in, so that where it is can be given in the
      * screen's coordinates rather than in that window's */
     struct window *pointer_in;
+#endif /* NO_WAYLAND */
 
     /*
      * The last thing the person did, as the compositor numbers them.
@@ -241,6 +255,7 @@ static struct {
  * are.
  * http://toshyp.atari.org/en/003007.html
  */
+#ifndef NO_WAYLAND
 static uint16_t scancode_for(xkb_keysym_t sym)
 {
     switch (sym)
@@ -282,6 +297,7 @@ static uint16_t scancode_for(xkb_keysym_t sym)
         default:                return 0;
     }
 }
+#endif /* NO_WAYLAND */
 
 static void key_post(uint16_t key)
 {
@@ -418,6 +434,11 @@ int gfx_mouse_known(void)
 
 uint16_t gfx_kstate()
 {
+#ifdef NO_WAYLAND
+    /* No keyboard, so nothing is being held down on it. Which is also the
+     * answer on a machine that has one and nobody logged in to use it. */
+    return 0;
+#else
     uint16_t state = 0;
 
     if (!w.xkb_state)
@@ -435,6 +456,7 @@ uint16_t gfx_kstate()
         state |= 0x0008;
 
     return state;
+#endif
 }
 
 /*
@@ -618,6 +640,10 @@ int gfx_button_take(int16_t *buttons, int16_t *x, int16_t *y)
 
     return 1;
 }
+
+/* Everything below here talks to a compositor, and a build without Wayland
+ * ends the file with the answers it would have arrived at without one */
+#ifndef NO_WAYLAND
 
 /* Keyboard ****************************************************************/
 
@@ -1688,3 +1714,109 @@ void gfx_present()
 
     wl_display_flush(w.display);
 }
+
+#else /* NO_WAYLAND */
+
+/*
+ * The same half, built where there is no Wayland to build it against.
+ *
+ * None of this is a special case for a test to run into. The emulator already
+ * has to work when there is nothing to connect to - gfx_open returns 0 on a
+ * machine where nobody is logged in, and everything else here is written to do
+ * nothing when it does - so what these answer is what the ordinary build
+ * answers on a machine with no desktop, and the emulator takes the same path
+ * through the AES either way.
+ *
+ * What is lost is being able to see it. The screen is in memory, which is
+ * where GEM draws and where a screenshot is taken from, and that is the part
+ * an application can observe.
+ */
+
+int gfx_open(struct surface *screen)
+{
+    (void)screen;
+
+    memset(&w, 0, sizeof w);
+
+    return 0;
+}
+
+void gfx_close()
+{
+    memset(&w, 0, sizeof w);
+}
+
+void gfx_forget(void)
+{
+    memset(&w, 0, sizeof w);
+}
+
+int gfx_showing()
+{
+    return 0;
+}
+
+void gfx_window_open(int16_t handle, const char *title, int16_t x, int16_t y,
+                     int16_t sw, int16_t sh)
+{
+    (void)handle; (void)title; (void)x; (void)y; (void)sw; (void)sh;
+}
+
+void gfx_window_move(int16_t handle, int16_t x, int16_t y,
+                     int16_t sw, int16_t sh)
+{
+    (void)handle; (void)x; (void)y; (void)sw; (void)sh;
+}
+
+void gfx_window_title(int16_t handle, const char *title)
+{
+    (void)handle; (void)title;
+}
+
+void gfx_window_close(int16_t handle)
+{
+    (void)handle;
+}
+
+void gfx_menu_open(int16_t x, int16_t y, int16_t sw, int16_t sh)
+{
+    (void)x; (void)y; (void)sw; (void)sh;
+}
+
+void gfx_menu_close(void)
+{
+}
+
+void gfx_dialog_open(struct surface *shows, int16_t x, int16_t y,
+                     int16_t sw, int16_t sh)
+{
+    (void)shows; (void)x; (void)y; (void)sw; (void)sh;
+}
+
+void gfx_dialog_close()
+{
+}
+
+/* Nothing to wait on beside the timer, which is what -1 says */
+int gfx_fd()
+{
+    return -1;
+}
+
+void gfx_dispatch()
+{
+}
+
+void gfx_dispatch_ready(void)
+{
+}
+
+void gfx_flush()
+{
+}
+
+void gfx_present()
+{
+}
+
+#endif /* NO_WAYLAND */

--- a/screen.c
+++ b/screen.c
@@ -39,7 +39,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef NO_WAYLAND
 #include <wayland-client.h>
+#endif
 
 /* How much larger than an ST pixel one on the desktop is. Three is a
  * reasonable guess at a modern display - a 640x400 screen becomes 1920x1200. */
@@ -167,6 +169,8 @@ void screen_from_display(int32_t pixels_w, int32_t pixels_h, int32_t out_scale,
     *width = (int16_t)w;
     *height = (int16_t)h;
 }
+
+#ifndef NO_WAYLAND
 
 /* What the compositor said about one display */
 struct display {
@@ -384,6 +388,26 @@ static int ask_the_compositor(int32_t *pixels_w, int32_t *pixels_h,
 
     return 1;
 }
+
+#else /* NO_WAYLAND */
+
+/*
+ * Nobody to ask, and no way to ask built in.
+ *
+ * This is the answer a build with Wayland in it also arrives at whenever there
+ * is no compositor running, so the caller has nothing new to handle: the
+ * screen falls back to the one GEM applications were written for and the
+ * planes stay as asked. See screen_mode below.
+ */
+static int ask_the_compositor(int32_t *pixels_w, int32_t *pixels_h,
+                              int32_t *out_scale)
+{
+    (void)pixels_w; (void)pixels_h; (void)out_scale;
+
+    return 0;
+}
+
+#endif /* NO_WAYLAND */
 
 void screen_mode(int16_t *width, int16_t *height, int16_t *planes)
 {


### PR DESCRIPTION
Wayland is a build dependency here rather than a run time one. The emulator already runs with nothing to show anything to - gfx_open answers that there is no window, screen.c's question about how large the display is goes unanswered, and the screen stays in memory, which is what happens on a machine where nobody is logged in and what every test in the suite does anyway. But the headers and the libraries still have to be there to compile it at all, and a build server has none of them: no wayland-client, no xkbcommon and no wayland-scanner.

NO_WAYLAND=1 leaves them out. In the Makefile it empties the four variables that carry them and the list of protocol files to generate, and defines NO_WAYLAND; in the two files that use them it ends each one where the compositor starts, with the answers the ordinary build already arrives at without one. gfx.c divides cleanly: the queues of keys and clicks and the input a test asks for on the command line are the half that never involved a compositor, and the windows are the other. screen.c divides at ask_the_compositor, which is the whole of what it uses Wayland for and which already has a caller written for it saying no.

So nothing new happens on the path a test takes. The emulator goes through the AES the same way, draws into the same screen and takes the same screenshot from it; what is lost is being able to see it, which is not something CI was going to do.

gfx.o and screen.o now depend on the Makefile, because the flag decides what those objects contain rather than merely how they were compiled, and make has no other way to see that turning it on or off has made them stale. That is the same reason the EmuTOS objects already depend on it.

The workflow passes it to both targets. Checked both ways on this machine: a clean build with pkg-config unable to find wayland at all passes make check and make emuvdi-check, and so does the ordinary build.