### PR TITLE
Optional GEM-like client side decorations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,19 @@ EMUTOSFILES = $(EMUTOS)/vdi/vdi_main.c $(EMUTOS)/vdi/vdi_control.c \
 WAYLAND_PROTOCOLS = $(shell pkg-config --variable=pkgdatadir wayland-protocols)
 WAYLAND_SCANNER = $(shell pkg-config --variable=wayland_scanner wayland-scanner)
 # The header is generated too, but only the source becomes an object
+#
+# One of the descriptions is carried rather than found. Layer shell is how the
+# panels and bars of a desktop are made, and it is what puts the menu bar at
+# the top of the display instead of wherever a window would go; it is not part
+# of wayland-protocols and is not packaged anywhere to depend on, so the file
+# itself is in protocols/. See the note above bar_create in gfx.c.
 WAYLANDGENERATED = gen/xdg-shell-protocol.c gen/xdg-dialog-protocol.c \
-                   gen/xdg-decoration-protocol.c
+                   gen/xdg-decoration-protocol.c \
+                   gen/wlr-layer-shell-protocol.c
 WAYLANDHEADERS = gen/xdg-shell-client-protocol.h \
                  gen/xdg-dialog-v1-client-protocol.h \
-                 gen/xdg-decoration-unstable-v1-client-protocol.h
+                 gen/xdg-decoration-unstable-v1-client-protocol.h \
+                 gen/wlr-layer-shell-unstable-v1-client-protocol.h
 WAYLANDFLAGS = $(shell pkg-config --cflags wayland-client xkbcommon)
 WAYLANDLIBS = $(shell pkg-config --libs wayland-client xkbcommon)
 
@@ -351,6 +359,15 @@ gen/xdg-decoration-protocol.c:
 gen/xdg-decoration-unstable-v1-client-protocol.h:
 	@mkdir -p gen/
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS)/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml $@
+
+# The one description that is carried here rather than found on the machine
+gen/wlr-layer-shell-protocol.c: protocols/wlr-layer-shell-unstable-v1.xml
+	@mkdir -p gen/
+	$(WAYLAND_SCANNER) private-code $< $@
+
+gen/wlr-layer-shell-unstable-v1-client-protocol.h: protocols/wlr-layer-shell-unstable-v1.xml
+	@mkdir -p gen/
+	$(WAYLAND_SCANNER) client-header $< $@
 
 gfx.o: $(WAYLANDHEADERS)
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,16 @@ the size box runs the desktop's own resize drag. The desktop is asked to put
 nothing round the outside, because a title bar inside a title bar is the
 picture of another computer again. Say `TOSEMU_DECORATIONS=desktop` to have it
 the other way round: the desktop's frame, and GEM's title bar left out of what
-is shown. Dialogs and the menu bar always take the desktop's, having no frame
-of their own to wear.
+is shown.
+
+Dialogs and the menu bar have no frame of their own to wear, so they ask the
+desktop for one. Not every desktop draws them: GNOME draws no frames at all
+round a Wayland window and has said it will not, which used to leave a dialog
+with nothing to move it by and nothing to close it with. Where the desktop
+draws none, one is drawn here instead - a GEM title bar, by the code that draws
+the ones on windows, so what appears is the bar of a GEM window and not an
+imitation of somebody else's desktop. `TOSEMU_DECORATIONS=gem` says to draw
+them that way everywhere without asking the desktop first.
 
 A resize drag shows a rubber band, which is what an ST did: the window becomes
 the size the drag has reached and what is in it is an outline of alternate black

--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ the ones on windows, so what appears is the bar of a GEM window and not an
 imitation of somebody else's desktop. `TOSEMU_DECORATIONS=gem` says to draw
 them that way everywhere without asking the desktop first.
 
+The menu bar goes at the top of the display, where a menu bar goes. Wayland
+gives a client no way to put a window anywhere, so this is asked for the way a
+desktop's own panels ask for it - the layer shell, which anchors a surface to an
+edge of a display above the ordinary windows, with no frame and nothing to drag
+it by. The description of that protocol is not part of wayland-protocols and is
+carried in `protocols/` rather than being another thing to install. It is an
+attempt rather than the way it is done: where the compositor has no layer shell,
+and GNOME does not, the bar is an ordinary window wherever the desktop decides
+to put it.
+
 A resize drag shows a rubber band, which is what an ST did: the window becomes
 the size the drag has reached and what is in it is an outline of alternate black
 and white pixels with the desktop showing through. The application hears nothing

--- a/aesframe.c
+++ b/aesframe.c
@@ -51,6 +51,7 @@
 #include <string.h>
 
 #include "emuvdi/emuvdi.h"
+#include "surface.h"
 
 /* What a window is made of, http://toshyp.atari.org/en/008002.html */
 #define W_NAME     (0x0001)
@@ -617,4 +618,75 @@ void aes_frame_draw(const struct aes_frame *frame)
     emuvdi_objc_draw(tree, F_BOX, 8, frame->x, frame->y, frame->w, frame->h);
 
     emuvdi_tree_free(tree);
+}
+
+/*
+ * A title bar for a window that has none of its own.
+ *
+ * A GEM window wears the frame above and needs nothing here. A dialog and the
+ * menu bar have no frame at all - GEM never gave them one, because on an ST
+ * they were drawn straight onto the screen and there was nothing to take hold
+ * of them by - so they ask the desktop to put its own frame round the outside.
+ * That is not everywhere a thing a desktop will do. GNOME draws no frames round
+ * a Wayland window and has said it will not, and a window with no frame
+ * anywhere has nothing to move it by, nothing to close it with and nothing
+ * saying what it is.
+ *
+ * So one is drawn, into a surface of the window's own that gfx.c shows as a
+ * strip along the top. It is drawn by the code above rather than by something
+ * new, which is the whole reason for this being here and not there: what comes
+ * out is the title bar of a GEM window, in the same font, with the same close
+ * box and the same light and dark for whether this is the window in front. A
+ * frame drawn to look like the desktop's would be an imitation of a desktop
+ * this program cannot see, and a frame drawn to look like neither would be a
+ * third kind of window on a screen that already has two.
+ *
+ * The surface is the caller's and is exactly the strip: the whole of it is the
+ * bar, and how tall that is is hbox, which is what gfx.c leaves room for. It
+ * says how wide as well, because a surface is a whole number of words across
+ * and a window is whatever width it is - so the bar is drawn to the window's
+ * width and the surface may be a few pixels wider than that.
+ */
+void host_frame_strip(struct surface *into, int16_t width, const char *name,
+                      int active, int closer)
+{
+    struct aes_frame frame;
+    struct surface *was;
+    int16_t handle, wchar, hchar, wbox, hbox;
+
+    if (!into)
+        return;
+
+    emuvdi_graf_handle(&handle, &wchar, &hchar, &wbox, &hbox);
+
+    memset(&frame, 0, sizeof frame);
+
+    /* A close box on everything that can be closed, and a window that is
+     * dragged by its title bar - which is what W_MOVE says, and is true here
+     * however the dragging is actually done */
+    frame.kind = W_NAME | W_MOVE | (closer ? W_CLOSE : 0);
+    frame.x = 0;
+    frame.y = 0;
+    frame.w = width;
+    frame.h = hbox;
+
+    /* Not copied and not written to, the way every other name here is not */
+    frame.name = (char *)name;
+    frame.active = active;
+
+    /*
+     * Onto the strip, whatever else is being drawn into.
+     *
+     * This is reached from the compositor's side rather than from a GEM call -
+     * a window is being opened, or the person has just made another one the
+     * one in front - so what is selected is whatever the application was last
+     * drawing into, and it has to be given back untouched.
+     */
+    was = surface_selected();
+
+    surface_select(into);
+    aes_frame_draw(&frame);
+
+    if (was)
+        surface_select(was);
 }

--- a/gfx.c
+++ b/gfx.c
@@ -93,6 +93,19 @@ void host_window_resized(int16_t handle, int16_t w, int16_t h);
 void host_window_activated(int16_t handle, int16_t active);
 
 /*
+ * A title bar drawn into a surface of a window's own, for a window that has
+ * none of GEM's and is on a desktop that draws none of its own either.
+ *
+ * The AES draws it, because what it draws is a GEM title bar - the same font,
+ * the same close box, the same light and dark for the window in front - and
+ * because the code that draws one is the AES's. See host_frame_strip in
+ * aesframe.c, which is also where the reasoning for it being GEM's rather than
+ * an imitation of somebody's desktop is written down.
+ */
+void host_frame_strip(struct surface *into, int16_t width, const char *name,
+                      int active, int closer);
+
+/*
  * How much larger than an ST pixel one on the desktop is.
  *
  * A whole number, because anything else is a blur: an ST pixel becomes a
@@ -195,6 +208,43 @@ struct window {
      * of the last configure */
     int active;
 
+    /*
+     * The frame this window draws for itself, and how tall it is in the
+     * screen's own pixels - nought for a window that is not drawing one.
+     *
+     * A GEM window carries its own frame in what it is showing and wants
+     * nothing here. A dialog and the menu bar have no frame of their own and
+     * ask the desktop for one, and a desktop is entitled to say no: GNOME
+     * draws no frames at all round a Wayland window, and expects every program
+     * to draw its own. A window with a frame from nowhere has nothing to move
+     * it by, nothing to close it with and nothing saying what it is, which is
+     * not a window so much as a rectangle that appeared.
+     *
+     * So one is drawn - by the AES, into this surface, and shown as a strip
+     * across the top of the window above what the window is showing. The
+     * window is that much taller than the rectangle it shows and everything
+     * that works in buffer pixels has to allow for it, which is what frame_h
+     * is for: it is the offset between the two, and it is nought whenever
+     * somebody else is drawing the frame.
+     */
+    struct surface *frame;
+    int16_t frame_h;
+
+    /* Whether GEM's own frame is in what this window shows, which settles the
+     * question before it is asked: such a window wants nothing from the
+     * desktop and nothing drawn here, whatever a compositor later says about
+     * frames in general */
+    int own_frame;
+
+    /* Whether that strip has a close box. Everything that can be closed has
+     * one, and the menu bar cannot: a close box that did nothing would be a
+     * trap rather than a decoration. */
+    int frame_closer;
+
+    /* What it says, kept because it is drawn again whenever the window becomes
+     * the one in front or stops being it */
+    char name[64];
+
     /* The compositor dismissed it, which only happens to menus */
     int gone;
 };
@@ -236,6 +286,18 @@ static struct {
     /* Which window the pointer is in, so that where it is can be given in the
      * screen's coordinates rather than in that window's */
     struct window *pointer_in;
+
+    /*
+     * And whether it is on the strip that window drew for itself, with how far
+     * along it in that window's own pixels.
+     *
+     * The strip is not part of the emulated screen. It is the frame, and a
+     * press on it is for the frame to answer - which is why where the pointer
+     * is on it is kept here rather than turned into a place on the screen, and
+     * why the AES hears nothing about either.
+     */
+    int on_frame;
+    int frame_x;
 #endif /* NO_WAYLAND */
 
     /*
@@ -853,6 +915,7 @@ static struct window *window_of(struct wl_surface *surface)
 static void pointer_gone(void)
 {
     w.pointer_in = 0;
+    w.on_frame = 0;
 
     if (!w.pressed && !w.buttons)
         return;
@@ -871,11 +934,33 @@ static void pointer_gone(void)
 
 static void pointer_at(struct window *win, wl_fixed_t x, wl_fixed_t y)
 {
+    int top;
+
     if (!win)
         return;
 
+    /* Where what the window is showing begins, which is under whatever strip
+     * the window drew for itself */
+    top = win->frame_h * win->scale;
+
+    /*
+     * The strip is not a place on the emulated screen.
+     *
+     * Told as one it would come out as the first row of what the window shows,
+     * which is a row with things on it that can be clicked: the top of a
+     * dialog, or the menu bar itself. So the pointer being there is written
+     * down as being there, the AES is told nothing, and where it is on the
+     * screen stays what it last was - which is the honest answer, the pointer
+     * not being on the screen at all.
+     */
+    w.on_frame = wl_fixed_to_int(y) < top;
+    w.frame_x = wl_fixed_to_int(x);
+
+    if (w.on_frame)
+        return;
+
     w.mouse_x = (int16_t)(win->sx + wl_fixed_to_int(x) / win->scale);
-    w.mouse_y = (int16_t)(win->sy + wl_fixed_to_int(y) / win->scale);
+    w.mouse_y = (int16_t)(win->sy + (wl_fixed_to_int(y) - top) / win->scale);
     w.mouse_known = 1;
 }
 
@@ -918,6 +1003,11 @@ static void pt_motion(void *data, struct wl_pointer *p, uint32_t time,
     pointer_at(w.pointer_in, x, y);
 }
 
+/* What a press on a window's own title bar is worth, which is written out
+ * below: it needs what the desktop's close box does, and that is further down
+ * than this */
+static void frame_press(struct window *win, int16_t buttons);
+
 static void pt_button(void *data, struct wl_pointer *p, uint32_t serial,
                       uint32_t time, uint32_t button, uint32_t state)
 {
@@ -933,6 +1023,25 @@ static void pt_button(void *data, struct wl_pointer *p, uint32_t serial,
         case 0x110: bit = 1; break;     /* BTN_LEFT */
         case 0x111: bit = 2; break;     /* BTN_RIGHT */
         default: return;
+    }
+
+    /*
+     * A press on the strip a window drew for itself belongs to the frame and
+     * not to the application. It is where the desktop's own title bar would
+     * have been, and what a title bar does - move the window, close it, put up
+     * the desktop's menu for it - is not a thing GEM is told about.
+     *
+     * The release is not waited for. Everything the strip does takes the
+     * pointer away from us the moment it starts: a drag and the window menu
+     * are the compositor's from the press onwards, and a close takes the window
+     * itself away.
+     */
+    if (w.on_frame && w.pointer_in)
+    {
+        if (state == WL_POINTER_BUTTON_STATE_PRESSED)
+            frame_press(w.pointer_in, bit);
+
+        return;
     }
 
     /*
@@ -1062,6 +1171,216 @@ static const struct xdg_surface_listener xdg_surface_listener = {
  * one - both written out below, and both wanted here */
 static void window_present(struct window *win);
 static int window_drag_preview(struct window *win, int width, int height);
+static int window_rebuffer(struct window *win, int width, int height,
+                           uint32_t format);
+
+/*
+ * Whether the frames the desktop is not drawing are drawn here instead.
+ *
+ * This is the same setting aeswind.c reads, and it is read here for the other
+ * half of the question. There it decides whether GEM draws a window's own title
+ * bar; here it decides who frames the windows that have no title bar of GEM's -
+ * a dialog, the menu bar, a window created without one.
+ *
+ * Unset, the desktop is asked and answers. Saying gem is saying not to ask at
+ * all, which is for a desktop whose frames are not wanted rather than one that
+ * has none to give - the answer is the same either way, and this is how to have
+ * it without waiting to be refused.
+ */
+static int frames_are_ours(void)
+{
+    static int asked;
+    static int wanted;
+
+    if (!asked)
+    {
+        const char *said = setting("TOSEMU_DECORATIONS");
+
+        wanted = said && strcmp(said, "gem") == 0;
+        asked = 1;
+    }
+
+    return wanted;
+}
+
+/* How large the box round a character is, which is what every strip of a
+ * window's frame is measured in: a title bar is one tall and a close box is
+ * one of each */
+static void frame_sizes(int16_t *wbox, int16_t *hbox)
+{
+    int16_t handle, wchar, hchar;
+
+    emuvdi_graf_handle(&handle, &wchar, &hchar, wbox, hbox);
+}
+
+/* What the strip says, drawn again: the name is not the only thing on it that
+ * changes, the bar itself being light or dark for whether this is the window
+ * somebody is working in */
+static void window_frame_paint(struct window *win)
+{
+    if (!win->frame)
+        return;
+
+    host_frame_strip(win->frame, win->sw, win->name, win->active,
+                     win->frame_closer);
+}
+
+/*
+ * Somewhere for the strip to be drawn: as wide as the window and as tall as a
+ * title bar, in the screen's own planes so that it is magnified and coloured
+ * like everything else the window shows.
+ *
+ * Made again whenever the window changes width, because a title bar is as wide
+ * as the window it is on and there is nothing to be done with one that is not.
+ */
+static void window_frame_make(struct window *win)
+{
+    if (win->frame)
+    {
+        surface_free(win->frame);
+        win->frame = 0;
+    }
+
+    if (!win->frame_h || !w.screen || win->sw <= 0)
+        return;
+
+    /*
+     * A whole number of words across, whatever the window's width is.
+     *
+     * The VDI works out how long a row is by rounding the width down to a word
+     * and surface_create rounds the allocation up, so a surface that is not a
+     * multiple of sixteen pixels wide is one where the two disagree - and every
+     * row the VDI draws lands a word further along than the row before it. An
+     * Atari screen was always a multiple of sixteen and the question never came
+     * up; a title bar is as wide as whatever window it is on, and a dialog is
+     * whatever width the application made it.
+     *
+     * The bar is still drawn as wide as the window. The few pixels past the end
+     * of it are never shown, the window being exactly as wide as it says.
+     */
+    win->frame = surface_create((uint16_t)((win->sw + 15) & ~15),
+                                (uint16_t)win->frame_h,
+                                surface_planes(w.screen));
+
+    /* No room for one. The window then has no frame at all, which is what it
+     * had before this was tried, rather than a gap where one was going to be */
+    if (!win->frame)
+    {
+        win->frame_h = 0;
+        return;
+    }
+
+    window_frame_paint(win);
+}
+
+/*
+ * How large the desktop may make the window, in the pixels the compositor
+ * counts in.
+ *
+ * A window that has said nothing about being resizable is pinned to the size it
+ * is, which is what a window without a size box is: GEM gave no way to resize
+ * one. A window that has said otherwise is held between the two sizes only the
+ * AES knows - see gfx_window_limits.
+ *
+ * Both have to allow for the strip the window draws for itself, which is why
+ * this is one place rather than the two it was said in. A window told it may
+ * not be taller than what it shows is a window whose frame does not fit in it.
+ */
+static void window_sizes(struct window *win)
+{
+    int16_t least_w, least_h, most_w, most_h;
+
+    if (!win->toplevel)
+        return;
+
+    if (win->max_w > 0 && win->max_h > 0)
+    {
+        least_w = win->min_w;
+        least_h = win->min_h;
+        most_w = win->max_w;
+        most_h = win->max_h;
+    }
+    else
+    {
+        least_w = most_w = win->sw;
+        least_h = most_h = win->sh;
+    }
+
+    xdg_toplevel_set_min_size(win->toplevel, least_w * win->scale,
+                              (least_h + win->frame_h) * win->scale);
+    xdg_toplevel_set_max_size(win->toplevel, most_w * win->scale,
+                              (most_h + win->frame_h) * win->scale);
+}
+
+/*
+ * Whether this window is to draw its own frame, which is not always known when
+ * the window is made.
+ *
+ * Asking the desktop for a frame is asking: the answer arrives as an event, and
+ * a compositor is entitled to answer that it draws none - which is what GNOME
+ * answers, and what any compositor with no decoration manager at all is saying
+ * by not having one. It may also change its mind later, a person having
+ * switched the desktop's frames off, and there is nothing else this could be
+ * told by.
+ *
+ * So the answer arrives here whenever it arrives. Before the window is up there
+ * is nothing to do but write it down, the size and the buffer being worked out
+ * from it in a moment; afterwards the window has to change size, because a
+ * frame that appears takes room the window does not have and one that goes
+ * leaves a strip of nothing where it was.
+ */
+static void window_frame_needed(struct window *win, int needed)
+{
+    int16_t wbox, hbox;
+
+    if (needed == (win->frame_h != 0))
+        return;
+
+    if (needed)
+    {
+        frame_sizes(&wbox, &hbox);
+        win->frame_h = hbox;
+    }
+    else
+        win->frame_h = 0;
+
+    if (!win->used)
+        return;
+
+    window_frame_make(win);
+    window_sizes(win);
+    window_rebuffer(win, win->width, (win->sh + win->frame_h) * win->scale,
+                    WL_SHM_FORMAT_XRGB8888);
+}
+
+/*
+ * What the desktop answered when it was asked to draw the frame, which is not
+ * always what it was asked for.
+ *
+ * A compositor that does not draw frames says so here, and saying so is the
+ * whole reason for listening: without it the request would be made, quietly
+ * refused, and the window would appear with no frame from anybody.
+ */
+static void decoration_configure(void *data,
+                                 struct zxdg_toplevel_decoration_v1 *d,
+                                 uint32_t mode)
+{
+    struct window *win = data;
+
+    (void)d;
+
+    /* A window that carries GEM's own frame asked for none of the desktop's
+     * and is not listening for an answer about one */
+    if (win->own_frame)
+        return;
+
+    window_frame_needed(win,
+                        mode != ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+}
+
+static const struct zxdg_toplevel_decoration_v1_listener decoration_listener = {
+    decoration_configure
+};
 
 /*
  * The compositor saying how large a window is to be, which is how a window
@@ -1093,7 +1412,7 @@ static void toplevel_configure(void *data, struct xdg_toplevel *t,
 
     (void)t;
 
-    if (!win->used || win->handle < 1)
+    if (!win->used)
         return;
 
     /*
@@ -1119,17 +1438,37 @@ static void toplevel_configure(void *data, struct xdg_toplevel *t,
     if (active != win->active)
     {
         win->active = active;
-        host_window_activated(win->handle, (int16_t)active);
+
+        /* A window drawing its own title bar draws it again, that bar being
+         * where light or dark says which window is in front */
+        if (win->frame)
+        {
+            window_frame_paint(win);
+            window_present(win);
+        }
+
+        if (win->handle >= 1)
+            host_window_activated(win->handle, (int16_t)active);
     }
+
+    /*
+     * Everything below is about how large the window is to be, and the dialog
+     * takes no part in it. It is the size the application made it, it is pinned
+     * to that size, and there is nobody to tell about a size anyway: the AES
+     * gives it no handle.
+     */
+    if (win->handle < 1)
+        return;
 
     /* Back into the screen's pixels, which is the only size anything above
      * here deals in. Rounding down rather than up: a window one pixel short of
      * what was asked for is a gap at the edge, and one pixel over is a row of
-     * the screen that does not exist. */
+     * the screen that does not exist. What the window draws for itself comes
+     * off first, that strip being the window's rather than the screen's. */
     if (width > 0 && height > 0 && !maximized)
     {
         int16_t asked_sw = (int16_t)(width / win->scale);
-        int16_t asked_sh = (int16_t)(height / win->scale);
+        int16_t asked_sh = (int16_t)(height / win->scale - win->frame_h);
 
         /*
          * Unless it is the size the window has just stopped being, said by a
@@ -1282,6 +1621,53 @@ static const struct xdg_toplevel_listener toplevel_listener = {
     toplevel_configure,
     toplevel_close
 };
+
+/*
+ * A press on the title bar a window drew for itself.
+ *
+ * That bar is the desktop's frame in everything but who drew it, so it does
+ * what the desktop's would have done: the close box closes the window, the
+ * other button puts up the desktop's own menu for it - which is where
+ * minimising lives, GEM having no gadget for something it cannot do - and
+ * anywhere else drags the window.
+ *
+ * The dragging and the menu are asked for rather than done. A client is not
+ * told where its windows are and cannot move one, so what a title bar does with
+ * a press is hand it back to the compositor and let the compositor run the
+ * drag, which is what GEM's own title bar does on a window that has one. See
+ * gfx_window_drag_move.
+ *
+ * Closing is the exception and is done here, because closing is not the
+ * desktop's idea of it: GEM's close box asks the application, which is why an
+ * application can ask whether you meant it. toplevel_close is what the
+ * desktop's own close button arrives at, and this is the same press.
+ */
+static void frame_press(struct window *win, int16_t buttons)
+{
+    int16_t wbox, hbox;
+
+    frame_sizes(&wbox, &hbox);
+
+    if (buttons == 1 && win->frame_closer && w.frame_x < wbox * win->scale)
+    {
+        toplevel_close(win, win->toplevel);
+        return;
+    }
+
+    /* Both of the rest have to be answering something the person did, and the
+     * serial of that is what proves it. There is nothing to answer when the
+     * input was made up rather than done, which is what happens under a test. */
+    if (!win->toplevel || !w.seat || !w.serial)
+        return;
+
+    if (buttons == 2)
+        xdg_toplevel_show_window_menu(win->toplevel, w.seat, w.serial,
+                                      w.frame_x, 0);
+    else
+        xdg_toplevel_move(win->toplevel, w.seat, w.serial);
+
+    wl_display_flush(w.display);
+}
 
 static void registry_global(void *data, struct wl_registry *registry,
                             uint32_t name, const char *interface,
@@ -1439,11 +1825,20 @@ static int window_resize(struct window *win, int16_t sw, int16_t sh)
     win->sh = sh;
     win->dragging = 0;
 
-    if (!window_rebuffer(win, sw * win->scale, sh * win->scale,
+    /* A title bar is as wide as the window it is on, so a window that has
+     * changed width needs another one */
+    if (sw != old_sw)
+        window_frame_make(win);
+
+    if (!window_rebuffer(win, sw * win->scale,
+                         (sh + win->frame_h) * win->scale,
                          WL_SHM_FORMAT_XRGB8888))
     {
         win->sw = old_sw;
         win->sh = old_sh;
+
+        if (sw != old_sw)
+            window_frame_make(win);
 
         return 0;
     }
@@ -1561,8 +1956,11 @@ static int window_create(struct window *win, const char *title,
                          int16_t sx, int16_t sy, int16_t sw, int16_t sh,
                          struct window *parent, int own_frame)
 {
+    uint32_t want;
+
     memset(win, 0, sizeof *win);
 
+    win->own_frame = own_frame;
     win->shows = shows;
     win->sx = sx;
     win->sy = sy;
@@ -1571,6 +1969,17 @@ static int window_create(struct window *win, const char *title,
     win->scale = screen_scale();
     win->width = sw * win->scale;
     win->height = sh * win->scale;
+
+    /* What a title bar of its own would say, if it turns out to need one */
+    if (title)
+    {
+        strncpy(win->name, title, sizeof win->name - 1);
+        win->name[sizeof win->name - 1] = 0;
+    }
+
+    /* Everything but the menu bar, which is not a window anybody can close: a
+     * close box that did nothing would be a trap */
+    win->frame_closer = win != &w.windows[MENUBAR];
 
     win->surface = wl_compositor_create_surface(w.compositor);
     win->xdg_surface = xdg_wm_base_get_xdg_surface(w.wm_base, win->surface);
@@ -1593,8 +2002,7 @@ static int window_create(struct window *win, const char *title,
      * knows: the smallest the frame will fit in, and what is left of the
      * screen it lays windows out on.
      */
-    xdg_toplevel_set_min_size(win->toplevel, win->width, win->height);
-    xdg_toplevel_set_max_size(win->toplevel, win->width, win->height);
+    window_sizes(win);
 
     /*
      * Whose frame goes round it.
@@ -1611,15 +2019,31 @@ static int window_create(struct window *win, const char *title,
      * window with no frame at all has nothing to take hold of: nothing to drag
      * it by and nothing to close it with. Saying so is not a formality either -
      * without it a compositor is entitled to assume the window draws its own.
+     *
+     * Asking is not getting. A compositor may answer that it draws no frames,
+     * which is what GNOME answers and what a compositor with no decoration
+     * manager at all has already said by not having one, and then the frame is
+     * drawn here - see window_frame_needed, which is where that answer arrives.
+     * A window with no manager to ask, or one told not to bother asking, knows
+     * without asking.
      */
+    if (own_frame)
+        want = ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE;
+    else if (w.decorations && !frames_are_ours())
+        want = ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE;
+    else
+    {
+        want = ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE;
+        window_frame_needed(win, 1);
+    }
+
     if (w.decorations)
     {
         win->decoration = zxdg_decoration_manager_v1_get_toplevel_decoration(
             w.decorations, win->toplevel);
-        zxdg_toplevel_decoration_v1_set_mode(
-            win->decoration,
-            own_frame ? ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE
-                      : ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
+        zxdg_toplevel_decoration_v1_add_listener(win->decoration,
+                                                 &decoration_listener, win);
+        zxdg_toplevel_decoration_v1_set_mode(win->decoration, want);
     }
 
     /*
@@ -1644,7 +2068,24 @@ static int window_create(struct window *win, const char *title,
     }
 
     wl_surface_commit(win->surface);
-    wl_display_roundtrip(w.display);    /* Waits for the first configure */
+
+    /* Waits for the first configure, and with it for whatever the desktop has
+     * to say about the frame */
+    wl_display_roundtrip(w.display);
+
+    /*
+     * Which is settled now, however it was settled, so the window is as tall as
+     * what it shows and whatever it is drawing above that.
+     *
+     * The sizes are said a second time for the same reason. They were said out
+     * of the size the window was going to be, and a window that has since
+     * gained a strip is one whose largest size no longer has room for its own
+     * frame - which a compositor is entitled to take literally and refuse to
+     * make it that big.
+     */
+    window_frame_make(win);
+    win->height = (sh + win->frame_h) * win->scale;
+    window_sizes(win);
 
     if (!window_buffer(win, WL_SHM_FORMAT_XRGB8888))
         return 0;
@@ -1674,6 +2115,8 @@ static void window_destroy(struct window *win)
         munmap(win->pixels, win->bytes);
     if (win->buffer)
         wl_buffer_destroy(win->buffer);
+    if (win->frame)
+        surface_free(win->frame);
     if (win->decoration)
         zxdg_toplevel_decoration_v1_destroy(win->decoration);
     if (win->dialog)
@@ -1964,10 +2407,7 @@ void gfx_window_limits(int16_t handle, int16_t min_w, int16_t min_h,
     win->max_w = max_w;
     win->max_h = max_h;
 
-    xdg_toplevel_set_min_size(win->toplevel, min_w * win->scale,
-                              min_h * win->scale);
-    xdg_toplevel_set_max_size(win->toplevel, max_w * win->scale,
-                              max_h * win->scale);
+    window_sizes(win);
 
     wl_surface_commit(win->surface);
 }
@@ -2051,16 +2491,32 @@ void gfx_window_menu(int16_t handle, int16_t x, int16_t y)
 
     xdg_toplevel_show_window_menu(win->toplevel, w.seat, w.serial,
                                   (x - win->sx) * win->scale,
-                                  (y - win->sy) * win->scale);
+                                  (y - win->sy + win->frame_h) * win->scale);
     wl_display_flush(w.display);
 }
 
 void gfx_window_title(int16_t handle, const char *title)
 {
+    struct window *win;
+
     if (handle < 1 || handle >= WINDOWS || !w.windows[handle].used)
         return;
 
-    xdg_toplevel_set_title(w.windows[handle].toplevel, title);
+    win = &w.windows[handle];
+
+    xdg_toplevel_set_title(win->toplevel, title);
+
+    /* And on the title bar the window draws for itself, where the name is the
+     * whole of what it is for */
+    if (title)
+    {
+        strncpy(win->name, title, sizeof win->name - 1);
+        win->name[sizeof win->name - 1] = 0;
+    }
+    else
+        win->name[0] = 0;
+
+    window_frame_paint(win);
 }
 
 void gfx_window_close(int16_t handle)
@@ -2123,11 +2579,16 @@ void gfx_menu_open(struct surface *shows, int16_t x, int16_t y,
      * directly above where the menu goes. Anchoring the menu's top left corner
      * there puts it under its title, and lets the compositor slide it along if
      * it would otherwise run off the edge of the screen.
+     *
+     * Whatever title bar the bar is drawing for itself is above all of that and
+     * counts, the point being said in the bar window's pixels rather than in
+     * the screen's.
      */
     where = xdg_wm_base_create_positioner(w.wm_base);
     xdg_positioner_set_size(where, win->width, win->height);
     xdg_positioner_set_anchor_rect(where, (x - bar->sx) * bar->scale,
-                                   (y - bar->sy) * bar->scale, 1, 1);
+                                   (y - bar->sy + bar->frame_h) * bar->scale,
+                                   1, 1);
     xdg_positioner_set_anchor(where, XDG_POSITIONER_ANCHOR_TOP_LEFT);
     xdg_positioner_set_gravity(where, XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
     xdg_positioner_set_constraint_adjustment(where,
@@ -2279,12 +2740,74 @@ void gfx_dispatch_ready(void)
  * the drag ending and the application answering it, and an application that
  * never answers is honestly showing what it kept.
  */
+/*
+ * One rectangle of a surface into the buffer, magnified, starting at a row of
+ * it.
+ *
+ * Everything a window shows goes through here: what the window is showing, and
+ * the title bar above it when the window is drawing one. The row it starts at
+ * is the whole of the difference between the two.
+ */
+static void window_magnify(struct window *win, struct surface *from,
+                           int16_t fx, int16_t fy, int16_t fw, int16_t fh,
+                           int top)
+{
+    int rows = top + fh * win->scale;
+    int columns = fw * win->scale;
+    int x, y, sx, sy;
+
+    if (rows > win->height)
+        rows = win->height;
+    if (columns > win->width)
+        columns = win->width;
+
+    for (y = 0; y < fh; y++)
+    {
+        if (top + y * win->scale >= rows)
+            break;
+
+        for (x = 0; x < fw; x++)
+        {
+            uint32_t argb;
+
+            if (x * win->scale >= columns)
+                break;
+
+            argb = emuvdi_palette_argb(
+                surface_pixel(from, (uint16_t)(fx + x), (uint16_t)(fy + y)));
+
+            /* The two tests above ask where a magnified pixel begins, and it
+             * is scale pixels wide and scale pixels tall. The buffer's size is
+             * whatever the compositor last sent and owes nothing to the scale,
+             * so it can end part of the way through one of them - and then the
+             * rest of that pixel is written past where the buffer stops. On
+             * the last row that is past the end of the mapping, which is a
+             * fault rather than a smear. So each of them is drawn as far as
+             * the buffer reaches and no further. */
+            for (sy = 0; sy < win->scale && top + y*win->scale + sy < rows; sy++)
+            {
+                uint32_t *row = win->pixels
+                              + (size_t)(top + y*win->scale + sy) * win->width
+                              + x*win->scale;
+
+                for (sx = 0; sx < win->scale && x*win->scale + sx < columns; sx++)
+                    row[sx] = argb;
+            }
+        }
+    }
+}
+
 static void window_picture(struct window *win)
 {
     uint32_t behind = emuvdi_palette_argb(0);
-    int rows = win->sh * win->scale;
+
+    /* Where what the window shows begins, which is under its own title bar
+     * when it has one */
+    int top = win->frame_h * win->scale;
+
+    int rows = top + win->sh * win->scale;
     int columns = win->sw * win->scale;
-    int x, y, sx, sy;
+    int x, y;
 
     if (rows > win->height)
         rows = win->height;
@@ -2306,41 +2829,10 @@ static void window_picture(struct window *win)
             row[x] = behind;
     }
 
-    for (y = 0; y < win->sh; y++)
-    {
-        if (y * win->scale >= rows)
-            break;
+    if (win->frame)
+        window_magnify(win, win->frame, 0, 0, win->sw, win->frame_h, 0);
 
-        for (x = 0; x < win->sw; x++)
-        {
-            uint32_t argb;
-
-            if (x * win->scale >= columns)
-                break;
-
-            argb = emuvdi_palette_argb(
-                surface_pixel(win->shows, (uint16_t)(win->sx + x),
-                              (uint16_t)(win->sy + y)));
-
-            /* The two tests above ask where a magnified pixel begins, and it
-             * is scale pixels wide and scale pixels tall. The buffer's size is
-             * whatever the compositor last sent and owes nothing to the scale,
-             * so it can end part of the way through one of them - and then the
-             * rest of that pixel is written past where the buffer stops. On
-             * the last row that is past the end of the mapping, which is a
-             * fault rather than a smear. So each of them is drawn as far as
-             * the buffer reaches and no further. */
-            for (sy = 0; sy < win->scale && y*win->scale + sy < rows; sy++)
-            {
-                uint32_t *row = win->pixels
-                              + (size_t)(y*win->scale + sy) * win->width
-                              + x*win->scale;
-
-                for (sx = 0; sx < win->scale && x*win->scale + sx < columns; sx++)
-                    row[sx] = argb;
-            }
-        }
-    }
+    window_magnify(win, win->shows, win->sx, win->sy, win->sw, win->sh, top);
 }
 
 /*

--- a/gfx.c
+++ b/gfx.c
@@ -1712,6 +1712,41 @@ void gfx_forget(void)
     memset(&w, 0, sizeof w);
 }
 
+/*
+ * Why there will be no windows.
+ *
+ * Failing to connect used to be answered with silence, on the grounds that a
+ * machine with nobody logged in is the ordinary case and says nothing worth
+ * hearing. On a desktop it is not ordinary at all, and the silence is the worst
+ * part of it: the emulator starts, the application runs, the screen is drawn -
+ * into memory, where nobody can see it - and nothing that happens afterwards
+ * explains why no window ever appeared.
+ *
+ * An X session is the case worth naming outright. tosemu shows its windows on
+ * Wayland and only on Wayland, so a person logged into Xorg, which is still
+ * what some machines are given by default, gets a program that looks like it
+ * started and then stopped. Neither is a fault to fix here - one is how the
+ * emulator has always run without a compositor - so what this does is say
+ * which of them happened.
+ *
+ * The two names read here are the session's own rather than tosemu's, which is
+ * why they are read directly instead of through settings.c. Nobody sets either
+ * of them to tell this program anything; they are how a program finds out what
+ * kind of session it is in.
+ */
+static void say_why_there_is_no_window(void)
+{
+    if (getenv("WAYLAND_DISPLAY"))
+        printf("GFX: there is a Wayland session here but connecting to it "
+               "failed, so the screen stays in memory\n");
+    else if (getenv("DISPLAY"))
+        printf("GFX: this is an X session, and tosemu shows its windows on "
+               "Wayland, so the screen stays in memory\n");
+    else
+        printf("GFX: there is no desktop session here, so the screen stays in "
+               "memory\n");
+}
+
 int gfx_open(struct surface *screen)
 {
     memset(&w, 0, sizeof w);
@@ -1728,7 +1763,10 @@ int gfx_open(struct surface *screen)
 
     w.display = wl_display_connect(0);
     if (!w.display)
-        return 0;   /* Nobody is logged in, which is the ordinary case here */
+    {
+        say_why_there_is_no_window();
+        return 0;
+    }
 
     w.registry = wl_display_get_registry(w.display);
     wl_registry_add_listener(w.registry, &registry_listener, 0);

--- a/gfx.c
+++ b/gfx.c
@@ -72,6 +72,7 @@
 #include "xdg-shell-client-protocol.h"
 #include "xdg-dialog-v1-client-protocol.h"
 #include "xdg-decoration-unstable-v1-client-protocol.h"
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #endif
 
 #include "surface.h"
@@ -146,6 +147,12 @@ struct window {
     struct xdg_popup *popup;
     struct xdg_dialog_v1 *dialog;
     struct zxdg_toplevel_decoration_v1 *decoration;
+
+    /* The menu bar, when the desktop lets a bar be a bar. It is a surface of
+     * the layer shell's rather than a window of the desktop's, so it has no
+     * xdg_surface and no toplevel and nothing below here uses either on it -
+     * see bar_create. */
+    struct zwlr_layer_surface_v1 *layer;
 
     struct wl_buffer *buffer;
     uint32_t *pixels;
@@ -272,6 +279,8 @@ static struct {
     struct xdg_wm_base *wm_base;
     struct xdg_wm_dialog_v1 *wm_dialog;
     struct zxdg_decoration_manager_v1 *decorations;
+    struct zwlr_layer_shell_v1 *layer_shell;
+    uint32_t layer_version;
 
     struct wl_seat *seat;
     struct wl_keyboard *keyboard;
@@ -1673,7 +1682,7 @@ static void registry_global(void *data, struct wl_registry *registry,
                             uint32_t name, const char *interface,
                             uint32_t version)
 {
-    (void)data; (void)version;
+    (void)data;
 
     if (!strcmp(interface, wl_compositor_interface.name))
         w.compositor = wl_registry_bind(registry, name,
@@ -1689,6 +1698,21 @@ static void registry_global(void *data, struct wl_registry *registry,
     else if (!strcmp(interface, xdg_wm_dialog_v1_interface.name))
         w.wm_dialog = wl_registry_bind(registry, name,
                                        &xdg_wm_dialog_v1_interface, 1);
+    /*
+     * The first version has everything a bar needs to be a bar: a size, an edge
+     * to hang off and a menu that can be dropped from it. The fourth adds the
+     * one thing a bar of this kind needs and an ordinary panel does not - a
+     * surface that takes the keyboard when it is clicked, which is what an
+     * application whose only window is its menu bar is typed into. So the
+     * fourth if it is there and whatever is there if it is not.
+     */
+    else if (!strcmp(interface, zwlr_layer_shell_v1_interface.name))
+    {
+        w.layer_version = version < 4 ? version : 4;
+        w.layer_shell = wl_registry_bind(registry, name,
+                                         &zwlr_layer_shell_v1_interface,
+                                         w.layer_version);
+    }
     else if (!strcmp(interface, wl_seat_interface.name))
     {
         w.seat = wl_registry_bind(registry, name, &wl_seat_interface, 5);
@@ -2095,6 +2119,123 @@ static int window_create(struct window *win, const char *title,
     return 1;
 }
 
+/*
+ * A layer surface says how large it is to be the same way a window does, and
+ * the answer has to be acknowledged before anything is attached to it.
+ *
+ * The size it names is the size that was asked for - a bar is not something a
+ * person resizes - so nothing is done with it. What matters is that it came,
+ * because that is what says the surface may be drawn.
+ */
+static void layer_configure(void *data, struct zwlr_layer_surface_v1 *s,
+                            uint32_t serial, uint32_t width, uint32_t height)
+{
+    struct window *win = data;
+
+    (void)width; (void)height;
+
+    zwlr_layer_surface_v1_ack_configure(s, serial);
+    win->configured = 1;
+}
+
+/* The compositor taking the bar away, which happens when the display it was on
+ * goes. It is put back the next time an application installs a menu, there
+ * being nothing here that could put it back sooner. */
+static void layer_closed(void *data, struct zwlr_layer_surface_v1 *s)
+{
+    struct window *win = data;
+
+    (void)s;
+
+    win->gone = 1;
+}
+
+static const struct zwlr_layer_surface_v1_listener layer_listener = {
+    layer_configure,
+    layer_closed
+};
+
+/*
+ * The menu bar, put where a menu bar goes.
+ *
+ * GEM's bar is the top row of the screen and nothing else was ever true of it:
+ * every application drew it there and every person looked for it there. As a
+ * window of the desktop's it lands wherever the desktop puts a window, which is
+ * usually the middle of the display, and a menu bar in the middle of the
+ * display with a title bar of its own above it is a strip of somebody else's
+ * furniture.
+ *
+ * Wayland gives a client no way to put a window anywhere. That is deliberate
+ * and the reasons are good ones, and they are all about ordinary windows. What
+ * it gives instead is the layer shell, which is how the panels and bars of a
+ * desktop are made: a surface anchored to an edge of a display, above the
+ * ordinary windows, out of the window list, with no frame and nothing to drag
+ * it by. That is what a menu bar is, so that is what this asks for.
+ *
+ * Not every compositor offers it - GNOME does not and has said it will not -
+ * which is why this is an attempt rather than the way it is done. Where there
+ * is no layer shell the bar is an ordinary window as it always was, with
+ * whatever frame it can get, wherever the desktop decides to put it.
+ *
+ * It is anchored to the top left corner rather than stretched across the top,
+ * because the bar is as wide as the emulated screen and that is a width the
+ * screen decides. Nothing is reserved: an exclusive zone would push every other
+ * program's windows down the display for as long as a GEM application happened
+ * to be running, which is more than a menu bar is entitled to ask for.
+ */
+static int bar_create(struct window *win, struct surface *shows,
+                      int16_t sw, int16_t sh)
+{
+    memset(win, 0, sizeof *win);
+
+    win->shows = shows;
+    win->sw = sw;
+    win->sh = sh;
+    win->scale = screen_scale();
+    win->width = sw * win->scale;
+    win->height = sh * win->scale;
+
+    win->surface = wl_compositor_create_surface(w.compositor);
+
+    /* No display named, which leaves the choice to the compositor: it knows
+     * which one the person is looking at and this does not */
+    win->layer = zwlr_layer_shell_v1_get_layer_surface(
+        w.layer_shell, win->surface, 0, ZWLR_LAYER_SHELL_V1_LAYER_TOP,
+        "tosemu-menu");
+    zwlr_layer_surface_v1_add_listener(win->layer, &layer_listener, win);
+
+    zwlr_layer_surface_v1_set_size(win->layer, win->width, win->height);
+    zwlr_layer_surface_v1_set_anchor(win->layer,
+                                     ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP
+                                     | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT);
+    zwlr_layer_surface_v1_set_exclusive_zone(win->layer, 0);
+
+    /*
+     * And it takes the keyboard when it is clicked, the way a window does.
+     *
+     * A panel wants nothing of the sort and the default is to have nothing to
+     * do with the keyboard, which is right for a clock and wrong here: an
+     * application whose only window is its menu bar - which is what a desk
+     * accessory usually is - would have no window that could be typed into at
+     * all. Saying so needs the fourth version of the protocol; a compositor
+     * with an older one keeps the bar it can, and an application there is typed
+     * into through one of its own windows.
+     */
+    if (w.layer_version >= 4)
+        zwlr_layer_surface_v1_set_keyboard_interactivity(
+            win->layer, ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND);
+
+    wl_surface_commit(win->surface);
+    wl_display_roundtrip(w.display);    /* Waits for the first configure */
+
+    if (!window_buffer(win, WL_SHM_FORMAT_XRGB8888))
+        return 0;
+
+    win->used = 1;
+
+    return 1;
+}
+
 static void window_destroy(struct window *win)
 {
     if (!win->used)
@@ -2123,6 +2264,8 @@ static void window_destroy(struct window *win)
         xdg_dialog_v1_destroy(win->dialog);
     if (win->popup)
         xdg_popup_destroy(win->popup);
+    if (win->layer)
+        zwlr_layer_surface_v1_destroy(win->layer);
     if (win->toplevel)
         xdg_toplevel_destroy(win->toplevel);
     if (win->xdg_surface)
@@ -2270,6 +2413,18 @@ void gfx_window_open(int16_t handle, const char *title, int16_t x, int16_t y,
         return;
 
     gfx_window_close(handle);
+
+    /* The menu bar goes at the top of the display where a bar belongs, when
+     * the desktop has a way of saying so - see bar_create */
+    if (handle == MENUBAR && w.layer_shell)
+    {
+        if (bar_create(&w.windows[handle], w.screen, sw, sh))
+            w.windows[handle].handle = handle;
+        else
+            window_destroy(&w.windows[handle]);
+
+        return;
+    }
 
     if (window_create(&w.windows[handle], title, w.screen, x, y, sw, sh, 0,
                       own_frame))
@@ -2504,7 +2659,10 @@ void gfx_window_title(int16_t handle, const char *title)
 
     win = &w.windows[handle];
 
-    xdg_toplevel_set_title(win->toplevel, title);
+    /* The menu bar has no toplevel to name when it is a bar of the layer
+     * shell's, and nowhere a name would be shown either */
+    if (win->toplevel)
+        xdg_toplevel_set_title(win->toplevel, title);
 
     /* And on the title bar the window draws for itself, where the name is the
      * whole of what it is for */
@@ -2595,9 +2753,23 @@ void gfx_menu_open(struct surface *shows, int16_t x, int16_t y,
         XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X
         | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y);
 
-    win->popup = xdg_surface_get_popup(win->xdg_surface, bar->xdg_surface,
+    /*
+     * Whose popup it is.
+     *
+     * A menu belongs to the bar either way. A bar that is a window of the
+     * desktop's is named as the parent outright; one that is a surface of the
+     * layer shell's is not a window and cannot be named that way, so the popup
+     * is made with no parent and the bar is told to adopt it - which is what
+     * the layer shell has get_popup for, and is how every panel on a desktop
+     * drops a menu.
+     */
+    win->popup = xdg_surface_get_popup(win->xdg_surface,
+                                       bar->layer ? 0 : bar->xdg_surface,
                                        where);
     xdg_positioner_destroy(where);
+
+    if (bar->layer)
+        zwlr_layer_surface_v1_get_popup(bar->layer, win->popup);
 
     xdg_popup_add_listener(win->popup, &popup_listener, win);
 
@@ -2912,6 +3084,11 @@ void gfx_present()
      * its own time; this is only the window going. */
     if (w.windows[MENU].gone)
         gfx_menu_close();
+
+    /* And a bar the compositor has taken away, which is what happens to a
+     * layer surface when the display it was anchored to goes */
+    if (w.windows[MENUBAR].gone)
+        window_destroy(&w.windows[MENUBAR]);
 
     for (i = 0; i < WINDOWS; i++)
         window_present(&w.windows[i]);

--- a/protocols/wlr-layer-shell-unstable-v1.xml
+++ b/protocols/wlr-layer-shell-unstable-v1.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_layer_shell_unstable_v1">
+  <copyright>
+    Copyright © 2017 Drew DeVault
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_layer_shell_v1" version="4">
+    <description summary="create surfaces that are layers of the desktop">
+      Clients can use this interface to assign the surface_layer role to
+      wl_surfaces. Such surfaces are assigned to a "layer" of the output and
+      rendered with a defined z-depth respective to each other. They may also be
+      anchored to the edges and corners of a screen and specify input handling
+      semantics. This interface should be suitable for the implementation of
+      many desktop shell components, and a broad number of other applications
+      that interact with the desktop.
+    </description>
+
+    <request name="get_layer_surface">
+      <description summary="create a layer_surface from a surface">
+        Create a layer surface for an existing surface. This assigns the role of
+        layer_surface, or raises a protocol error if another role is already
+        assigned.
+
+        Creating a layer surface from a wl_surface which has a buffer attached
+        or committed is a client error, and any attempts by a client to attach
+        or manipulate a buffer prior to the first layer_surface.configure call
+        must also be treated as errors.
+
+        After creating a layer_surface object and setting it up, the client
+        must perform an initial commit without any buffer attached.
+        The compositor will reply with a layer_surface.configure event.
+        The client must acknowledge it and is then allowed to attach a buffer
+        to map the surface.
+
+        You may pass NULL for output to allow the compositor to decide which
+        output to use. Generally this will be the one that the user most
+        recently interacted with.
+
+        Clients can specify a namespace that defines the purpose of the layer
+        surface.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_layer_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="layer" type="uint" enum="layer" summary="layer to add this surface to"/>
+      <arg name="namespace" type="string" summary="namespace for the layer surface"/>
+    </request>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="wl_surface has another role"/>
+      <entry name="invalid_layer" value="1" summary="layer value is invalid"/>
+      <entry name="already_constructed" value="2" summary="wl_surface has a buffer attached or committed"/>
+    </enum>
+
+    <enum name="layer">
+      <description summary="available layers for surfaces">
+        These values indicate which layers a surface can be rendered in. They
+        are ordered by z depth, bottom-most first. Traditional shell surfaces
+        will typically be rendered between the bottom and top layers.
+        Fullscreen shell surfaces are typically rendered at the top layer.
+        Multiple surfaces can share a single layer, and ordering within a
+        single layer is undefined.
+      </description>
+
+      <entry name="background" value="0"/>
+      <entry name="bottom" value="1"/>
+      <entry name="top" value="2"/>
+      <entry name="overlay" value="3"/>
+    </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_layer_surface_v1" version="4">
+    <description summary="layer metadata interface">
+      An interface that may be implemented by a wl_surface, for surfaces that
+      are designed to be rendered as a layer of a stacked desktop-like
+      environment.
+
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
+
+      Attaching a null buffer to a layer surface unmaps it.
+
+      Unmapping a layer_surface means that the surface cannot be shown by the
+      compositor until it is explicitly mapped again. The layer_surface
+      returns to the state it had right after layer_shell.get_layer_surface.
+      The client can re-map the surface by performing a commit without any
+      buffer attached, waiting for a configure event and handling it as usual.
+    </description>
+
+    <request name="set_size">
+      <description summary="sets the size of the surface">
+        Sets the size of the surface in surface-local coordinates. The
+        compositor will display the surface centered with respect to its
+        anchors.
+
+        If you pass 0 for either value, the compositor will assign it and
+        inform you of the assignment in the configure event. You must set your
+        anchor to opposite edges in the dimensions you omit; not doing so is a
+        protocol error. Both values are 0 by default.
+
+        Size is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </request>
+
+    <request name="set_anchor">
+      <description summary="configures the anchor point of the surface">
+        Requests that the compositor anchor the surface to the specified edges
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
+        'left'), then the anchor point will be the intersection of the edges
+        (e.g. the top left corner of the output); otherwise the anchor point
+        will be centered on that edge, or in the center if none is specified.
+
+        Anchor is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="anchor" type="uint" enum="anchor"/>
+    </request>
+
+    <request name="set_exclusive_zone">
+      <description summary="configures the exclusive geometry of this surface">
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
+        implementation-dependent - do not assume that this region will not
+        actually be occluded.
+
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
+
+        Surfaces that do not wish to have an exclusive zone may instead specify
+        how they should interact with surfaces that do. If set to zero, the
+        surface indicates that it would like to be moved to avoid occluding
+        surfaces with a positive exclusive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accommodate for other
+        surfaces, and the compositor should extend it all the way to the edges
+        it is anchored to.
+
+        For example, a panel might set its exclusive zone to 10, so that
+        maximized shell surfaces are not shown on top of it. A notification
+        might set its exclusive zone to 0, so that it is moved to avoid
+        occluding the panel, but shell surfaces are shown underneath it. A
+        wallpaper or lock screen might set their exclusive zone to -1, so that
+        they stretch below or over the panel.
+
+        The default value is 0.
+
+        Exclusive zone is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="zone" type="int"/>
+    </request>
+
+    <request name="set_margin">
+      <description summary="sets a margin from the anchor point">
+        Requests that the surface be placed some distance away from the anchor
+        point on the output, in surface-local coordinates. Setting this value
+        for edges you are not anchored to has no effect.
+
+        The exclusive zone includes the margin.
+
+        Margin is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="top" type="int"/>
+      <arg name="right" type="int"/>
+      <arg name="bottom" type="int"/>
+      <arg name="left" type="int"/>
+    </request>
+
+    <enum name="keyboard_interactivity">
+      <description summary="types of keyboard interaction possible for a layer shell surface">
+        Types of keyboard interaction possible for layer shell surfaces. The
+        rationale for this is twofold: (1) some applications are not interested
+        in keyboard events and not allowing them to be focused can improve the
+        desktop experience; (2) some applications will want to take exclusive
+        keyboard focus.
+      </description>
+
+      <entry name="none" value="0">
+        <description summary="no keyboard focus is possible">
+          This value indicates that this surface is not interested in keyboard
+          events and the compositor should never assign it the keyboard focus.
+
+          This is the default value, set for newly created layer shell surfaces.
+
+          This is useful for e.g. desktop widgets that display information or
+          only have interaction with non-keyboard input devices.
+        </description>
+      </entry>
+      <entry name="exclusive" value="1">
+        <description summary="request exclusive keyboard focus">
+          Request exclusive keyboard focus if this surface is above the shell surface layer.
+
+          For the top and overlay layers, the seat will always give
+          exclusive keyboard focus to the top-most layer which has keyboard
+          interactivity set to exclusive. If this layer contains multiple
+          surfaces with keyboard interactivity set to exclusive, the compositor
+          determines the one receiving keyboard events in an implementation-
+          defined manner. In this case, no guarantee is made when this surface
+          will receive keyboard focus (if ever).
+
+          For the bottom and background layers, the compositor is allowed to use
+          normal focus semantics.
+
+          This setting is mainly intended for applications that need to ensure
+          they receive all keyboard events, such as a lock screen or a password
+          prompt.
+        </description>
+      </entry>
+      <entry name="on_demand" value="2" since="4">
+        <description summary="request regular keyboard focus semantics">
+          This requests the compositor to allow this surface to be focused and
+          unfocused by the user in an implementation-defined manner. The user
+          should be able to unfocus this surface even regardless of the layer
+          it is on.
+
+          Typically, the compositor will want to use its normal mechanism to
+          manage keyboard focus between layer shell surfaces with this setting
+          and regular toplevels on the desktop layer (e.g. click to focus).
+          Nevertheless, it is possible for a compositor to require a special
+          interaction to focus or unfocus layer shell surfaces (e.g. requiring
+          a click even if focus follows the mouse normally, or providing a
+          keybinding to switch focus between layers).
+
+          This setting is mainly intended for desktop shell components (e.g.
+          panels) that allow keyboard interaction. Using this option can allow
+          implementing a desktop shell that can be fully usable without the
+          mouse.
+        </description>
+      </entry>
+    </enum>
+
+    <request name="set_keyboard_interactivity">
+      <description summary="requests keyboard events">
+        Set how keyboard events are delivered to this surface. By default,
+        layer shell surfaces do not receive keyboard events; this request can
+        be used to change this.
+
+        This setting is inherited by child surfaces set by the get_popup
+        request.
+
+        Layer surfaces receive pointer, touch, and tablet events normally. If
+        you do not want to receive them, set the input region on your surface
+        to an empty region.
+
+        Keyboard interactivity is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="keyboard_interactivity" type="uint" enum="keyboard_interactivity"/>
+    </request>
+
+    <request name="get_popup">
+      <description summary="assign this layer_surface as an xdg_popup parent">
+        This assigns an xdg_popup's parent to this layer_surface.  This popup
+        should have been created via xdg_surface::get_popup with the parent set
+        to NULL, and this request must be invoked before committing the popup's
+        initial state.
+
+        See the documentation of xdg_popup for more details about what an
+        xdg_popup is and how it is used.
+      </description>
+      <arg name="popup" type="object" interface="xdg_popup"/>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+        When a configure event is received, if a client commits the
+        surface in response to the configure event, then the client
+        must make an ack_configure request sometime before the commit
+        request, passing along the serial of the configure event.
+
+        If the client receives multiple configure events before it
+        can respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending
+        an ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        A client may send multiple ack_configure requests before committing, but
+        only the last request sent before a commit indicates which configure
+        event the client really is responding to.
+      </description>
+      <arg name="serial" type="uint" summary="the serial from the configure event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the layer_surface">
+        This request destroys the layer surface.
+      </description>
+    </request>
+
+    <event name="configure">
+      <description summary="suggest a surface change">
+        The configure event asks the client to resize its surface.
+
+        Clients should arrange their surface for the new states, and then send
+        an ack_configure request with the serial sent in this configure event at
+        some point before committing the new surface.
+
+        The client is free to dismiss all but the last configure event it
+        received.
+
+        The width and height arguments specify the size of the window in
+        surface-local coordinates.
+
+        The size is a hint, in the sense that the client is free to ignore it if
+        it doesn't resize, pick a smaller size (to satisfy aspect ratio or
+        resize in steps of NxM pixels). If the client picks a smaller size and
+        is anchored to two opposite anchors (e.g. 'top' and 'bottom'), the
+        surface will be centered on this axis.
+
+        If the width or height arguments are zero, it means the client should
+        decide its own window dimension.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+
+    <event name="closed">
+      <description summary="surface should be closed">
+        The closed event is sent by the compositor when the surface will no
+        longer be shown. The output may have been destroyed or the user may
+        have asked for it to be removed. Further changes to the surface will be
+        ignored. The client should destroy the resource after receiving this
+        event, and create a new surface if they so choose.
+      </description>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid_surface_state" value="0" summary="provided surface state is invalid"/>
+      <entry name="invalid_size" value="1" summary="size is invalid"/>
+      <entry name="invalid_anchor" value="2" summary="anchor bitfield is invalid"/>
+      <entry name="invalid_keyboard_interactivity" value="3" summary="keyboard interactivity is invalid"/>
+    </enum>
+
+    <enum name="anchor" bitfield="true">
+      <entry name="top" value="1" summary="the top edge of the anchor rectangle"/>
+      <entry name="bottom" value="2" summary="the bottom edge of the anchor rectangle"/>
+      <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
+      <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
+    </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
As GNOME does not support server side decorations.

Also, make the menu moveable and resizable (width only) in it's own right using client side decorations.