### PR TITLE
GEM: a window wore the compositor's placeholder icon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,19 @@ WAYLAND_PROTOCOLS = $(shell pkg-config --variable=pkgdatadir wayland-protocols)
 WAYLAND_SCANNER = $(shell pkg-config --variable=wayland_scanner wayland-scanner)
 # The header is generated too, but only the source becomes an object
 WAYLANDGENERATED = $(GEN)/xdg-shell-protocol.c $(GEN)/xdg-dialog-protocol.c \
-                   $(GEN)/xdg-decoration-protocol.c
+                   $(GEN)/xdg-decoration-protocol.c \
+                   $(GEN)/xdg-toplevel-icon-protocol.c
 WAYLANDHEADERS = $(GEN)/xdg-shell-client-protocol.h \
                  $(GEN)/xdg-dialog-v1-client-protocol.h \
-                 $(GEN)/xdg-decoration-unstable-v1-client-protocol.h
+                 $(GEN)/xdg-decoration-unstable-v1-client-protocol.h \
+                 $(GEN)/xdg-toplevel-icon-v1-client-protocol.h
 WAYLANDFLAGS = $(shell pkg-config --cflags wayland-client xkbcommon)
 WAYLANDLIBS = $(shell pkg-config --libs wayland-client xkbcommon)
+
+# The picture that goes on the windows, which only the half of gfx.c that
+# opens them wants - so it is named with the rest of what that half needs. See
+# the rule that makes it.
+WINDOWICON = $(GEN)/rsc/window-icon.h
 
 # Talking to the compositor without showing anything, which is what asking how
 # large the display is amounts to. The daemon wants this and not the rest: it
@@ -89,6 +96,7 @@ WAYLANDONLYLIBS = $(shell pkg-config --libs wayland-client)
 ifdef NO_WAYLAND
 WAYLANDGENERATED =
 WAYLANDHEADERS =
+WINDOWICON =
 WAYLANDFLAGS = -DNO_WAYLAND
 WAYLANDLIBS =
 WAYLANDONLYLIBS =
@@ -178,7 +186,8 @@ EMUTOSLDFLAGS = -no-pie
 all: $(BIN)/tosemu $(BIN)/tosaesd
 
 .PHONY: all tests check devpac-tests devpac-check lattice-tests lattice-check \
-        emuvdi-check screen-check settings-check scrap-check demos clean
+        emuvdi-check screen-check settings-check scrap-check icon-check \
+        demos clean
 
 # A checkout without --recurse-submodules leaves the submodule an empty
 # directory, and "No rule to make target" says nothing about why. This catches
@@ -360,6 +369,21 @@ $(GEN)/rsc/tray-icon.h: $(SRC)/rsc/tray.svg $(SRC)/rsc/icon-to-c.py
 
 $(OBJ)/aesdtray.o: $(GEN)/rsc/tray-icon.h
 
+# The picture that goes on the windows, taken out of EmuTOS's own icons.
+#
+# A task bar shows an icon beside a window's name, and with nothing to show it
+# shows the compositor's placeholder - so a GEM application appeared under a
+# mark belonging to Wayland. What it should be is what the desktop the program
+# was written for would have shown for it, which is the generic application
+# icon in EMUICON.RSC, number six there and IG_APPL to the EmuTOS desktop.
+#
+# It is taken from the submodule rather than copied here, for the same reason
+# the VDI is compiled out of it: it is EmuTOS's picture and this is where
+# EmuTOS keeps it. Nothing is written back - the resource is read as it stands.
+$(GEN)/rsc/window-icon.h: $(EMUTOS)/extras/emuicon1.rsc $(SRC)/rsc/emuicon-to-c.py
+	@mkdir -p $(dir $@)
+	python3 $(SRC)/rsc/emuicon-to-c.py $< 6 $@
+
 $(BIN)/tosaesd: $(DAEMONOBJECTS) $(OBJ)/screen.o $(OBJ)/settings.o
 	@mkdir -p $(BIN)
 	$(LD) $(LDFLAGS) $^ $(DBUSLIBS) $(WAYLANDONLYLIBS) -o $@
@@ -386,6 +410,20 @@ $(BIN)/settingstest: $(SRC)/settingstest.c $(OBJ)/settings.o
 
 settings-check: $(BIN)/settingstest
 	./$(BIN)/settingstest
+
+# The picture on the windows, checked without a task bar to put it in. Host
+# built for the same reason as the two above, and it checks the one half of
+# this that can be checked: which picture came out of somebody else's resource
+# file. What a compositor then does with it cannot be arranged by a test.
+#
+# It is built even when the emulator is not, because the header it reads is the
+# picture and not the Wayland half that shows it.
+$(BIN)/icontest: $(SRC)/icontest.c $(GEN)/rsc/window-icon.h
+	@mkdir -p $(BIN)
+	$(CC) $(CFLAGS) $(LDFLAGS) $< -o $@
+
+icon-check: $(BIN)/icontest
+	./$(BIN)/icontest
 
 # The character set and the line endings, checked without an emulator. Host
 # built for the same reason as the rest of these: an emulated program can say
@@ -438,7 +476,15 @@ $(GEN)/xdg-decoration-unstable-v1-client-protocol.h:
 	@mkdir -p $(GEN)
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS)/unstable/xdg-decoration/xdg-decoration-unstable-v1.xml $@
 
-$(OBJ)/gfx.o: $(WAYLANDHEADERS)
+$(GEN)/xdg-toplevel-icon-protocol.c:
+	@mkdir -p $(GEN)
+	$(WAYLAND_SCANNER) private-code $(WAYLAND_PROTOCOLS)/staging/xdg-toplevel-icon/xdg-toplevel-icon-v1.xml $@
+
+$(GEN)/xdg-toplevel-icon-v1-client-protocol.h:
+	@mkdir -p $(GEN)
+	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS)/staging/xdg-toplevel-icon/xdg-toplevel-icon-v1.xml $@
+
+$(OBJ)/gfx.o: $(WAYLANDHEADERS) $(WINDOWICON)
 
 # Every object needs the generated m68kops.h, so none of them may be compiled
 # before m64kmake has run
@@ -461,7 +507,8 @@ $(BIN)/m64kmake: $(SRC)/Musashi/m68kmake.c
 	@mkdir -p $(BIN)
 	$(CC) $(CFLAGS) -no-pie $< -o $@
 
-check: $(BIN)/tosemu $(BIN)/tosaesd screen-check settings-check scrap-check
+check: $(BIN)/tosemu $(BIN)/tosaesd screen-check settings-check scrap-check \
+       icon-check
 	$(MAKE) -C tests check
 
 devpac-check: $(BIN)/tosemu

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ picture of another computer again. Say `TOSEMU_DECORATIONS=desktop` to have it
 the other way round: the desktop's frame, and GEM's title bar left out of what
 is shown.
 
+Every window carries EmuTOS's generic application icon, which is what a task
+bar or a window switcher shows beside its name. It is read out of the icon
+resource EmuTOS ships and made larger by repeating its pixels, so what appears
+in the switcher is a thirty two pixel ST icon at whatever size the desktop asked
+for rather than a smoothed one. A desktop too old to have heard of window icons
+shows what it showed before, which is its own placeholder. See `src/rsc/README`.
+
 A dialog has no frame of its own to wear, so it asks the desktop for one. Not
 every desktop draws them: GNOME draws no frames at all round a Wayland window
 and has said it will not, which used to leave a dialog with nothing to move it

--- a/TODO
+++ b/TODO
@@ -252,6 +252,10 @@
   already knows how to start programs. That wants deciding rather than
   assuming, because the plan says otherwise.
 
-- No .desktop files are written for GEM programs, so one has no icon and no
-  name of its own in a launcher or a task bar. The windows already carry an
-  app_id, which is the half that needs no files.
+- No .desktop files are written for GEM programs, so one has no name of its own
+  in a launcher or a task bar, and no picture of its own either. The windows
+  already carry an app_id and EmuTOS's generic application icon, which are the
+  halves that need no files: a task bar shows what the desktop the program came
+  from would have shown for it, which is the right answer for a program that
+  never said what its own icon was. What a file would add is a name and a
+  picture belonging to the program rather than to the emulator running it.

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -74,6 +74,21 @@
 #include "xdg-shell-client-protocol.h"
 #include "xdg-dialog-v1-client-protocol.h"
 #include "xdg-decoration-unstable-v1-client-protocol.h"
+#include "xdg-toplevel-icon-v1-client-protocol.h"
+
+/* The picture that goes on every window, which the build takes out of EmuTOS's
+ * own icons - see the rule in the Makefile and src/rsc/README. It is in the
+ * program rather than beside it because an icon looked for at run time is an
+ * icon that can be missing, and a window with none is back to the placeholder
+ * this is here to replace. */
+#include "rsc/window-icon.h"
+
+/* How many sizes of it are worth offering, and how much larger than it was
+ * drawn the largest of them may be. A compositor asks for one size or a few;
+ * these are only here so that a strange answer cannot ask for an unbounded
+ * amount of memory. */
+#define ICON_SIZES     (8)
+#define ICON_LARGEST   (8)
 #endif
 
 #include "surface.h"
@@ -290,6 +305,30 @@ static struct {
     struct xdg_wm_base *wm_base;
     struct xdg_wm_dialog_v1 *wm_dialog;
     struct zxdg_decoration_manager_v1 *decorations;
+
+    /*
+     * The picture a task bar shows beside a window's name, made once and put
+     * on every window there is.
+     *
+     * One icon does for all of them because that is what it is: an icon of
+     * this window belongs to the toplevel rather than to the application, and
+     * every one of these toplevels is the same GEM application. The protocol
+     * says as much - an icon may be set on any number of toplevels, and is
+     * fixed from the first time it is.
+     *
+     * The buffers it was built out of are kept because they have to be. A
+     * compositor reads them whenever it draws the icon, so they belong to it
+     * for as long as the icon does, and letting go of one is an error the
+     * protocol names.
+     */
+    struct xdg_toplevel_icon_manager_v1 *icon_manager;
+    struct xdg_toplevel_icon_v1 *icon;
+    struct wl_buffer *icon_buffers[ICON_SIZES];
+
+    /* What sizes the compositor said it would like, which it says once when
+     * the manager is bound and never again */
+    int icon_wanted[ICON_SIZES];
+    int icon_wanted_count;
 
     struct wl_seat *seat;
     struct wl_keyboard *keyboard;
@@ -2136,6 +2175,45 @@ static void frame_press(struct window *win, int16_t buttons)
     wl_display_flush(w.display);
 }
 
+/*
+ * What sizes of icon the compositor would like, which are noted and answered
+ * as nearly as a picture of this kind can answer them.
+ *
+ * It asks for whatever its task bar and its window switcher draw at - ninety
+ * six pixels on this desk, twenty two or forty eight on another. The icon is
+ * thirty two pixels of black and white drawn one at a time, so the only sizes
+ * it has an honest answer for are whole multiples of that: anything else is
+ * either a resampling, which is the smoothing this whole file exists to avoid,
+ * or pixels of two different widths side by side, which on straight lines
+ * looks like a mistake rather than like a large pixel.
+ *
+ * So each size asked for is answered with the nearest whole multiple, and
+ * whatever is left over is a scaling the compositor does - by a quarter at
+ * worst, rather than by whatever the difference happened to be. See icon_make.
+ */
+static void icon_size(void *data, struct xdg_toplevel_icon_manager_v1 *manager,
+                      int32_t size)
+{
+    (void)data; (void)manager;
+
+    if (size > 0 && w.icon_wanted_count < ICON_SIZES)
+        w.icon_wanted[w.icon_wanted_count++] = (int)size;
+}
+
+/* Nothing to do: what the sizes are for is settled in one go afterwards, and
+ * the roundtrip in gfx_open is what waits for them to have all arrived */
+static void icon_sizes_done(void *data,
+                            struct xdg_toplevel_icon_manager_v1 *manager)
+{
+    (void)data; (void)manager;
+}
+
+static const struct xdg_toplevel_icon_manager_v1_listener
+icon_manager_listener = {
+    icon_size,
+    icon_sizes_done,
+};
+
 static void registry_global(void *data, struct wl_registry *registry,
                             uint32_t name, const char *interface,
                             uint32_t version)
@@ -2156,6 +2234,14 @@ static void registry_global(void *data, struct wl_registry *registry,
     else if (!strcmp(interface, xdg_wm_dialog_v1_interface.name))
         w.wm_dialog = wl_registry_bind(registry, name,
                                        &xdg_wm_dialog_v1_interface, 1);
+    else if (!strcmp(interface, xdg_toplevel_icon_manager_v1_interface.name))
+    {
+        w.icon_manager =
+            wl_registry_bind(registry, name,
+                             &xdg_toplevel_icon_manager_v1_interface, 1);
+        xdg_toplevel_icon_manager_v1_add_listener(w.icon_manager,
+                                                  &icon_manager_listener, 0);
+    }
     else if (!strcmp(interface, wl_seat_interface.name))
     {
         w.seat = wl_registry_bind(registry, name, &wl_seat_interface, 5);
@@ -2222,6 +2308,160 @@ static int window_buffer(struct window *win, uint32_t format)
     close(fd);
 
     return win->buffer != 0;
+}
+
+/*
+ * Which sizes of the icon are worth building, given what the compositor asked
+ * for.
+ *
+ * Every one of them is a whole number of copies of each ST pixel, so a size
+ * that was asked for is answered with the multiple nearest it rather than
+ * exactly - ninety six is three of them and is answered exactly, forty eight
+ * is one and a half and is answered with sixty four.
+ *
+ * A compositor that asked for nothing has said it does not mind, and gets the
+ * picture and a doubling of it: one for a task bar and one for a switcher on a
+ * display where everything is twice the size.
+ */
+static int icon_multiples(int *multiples)
+{
+    int count = 0;
+    int i, j;
+
+    for (i = 0; i < w.icon_wanted_count; i++)
+    {
+        int want = (w.icon_wanted[i] + WINDOW_ICON_SIZE / 2) / WINDOW_ICON_SIZE;
+
+        if (want < 1)
+            want = 1;
+        if (want > ICON_LARGEST)
+            want = ICON_LARGEST;
+
+        /* Two sizes that round to the same multiple are one buffer, not two */
+        for (j = 0; j < count; j++)
+            if (multiples[j] == want)
+                break;
+
+        if (j == count)
+            multiples[count++] = want;
+    }
+
+    if (count == 0)
+    {
+        multiples[count++] = 1;
+        multiples[count++] = 2;
+    }
+
+    return count;
+}
+
+/*
+ * The icon, built once out of the picture compiled into the program.
+ *
+ * Every size goes in one piece of shared memory and one pool. They are handed
+ * over together and kept for as long as the program runs, so there is nothing
+ * to be gained by giving each its own file, and a compositor that would have
+ * had to map several maps one instead.
+ *
+ * Making the picture larger is repeating its pixels rather than resampling
+ * them, for the reason the emulated screen is magnified the same way: an ST
+ * pixel is a large old pixel and the only honest way to draw a large one is to
+ * draw a block. Doing it here rather than in the header is what lets the size
+ * be one the compositor asked for - which is not known until it has said so.
+ *
+ * The bytes in the header are alpha, red, green and blue in that order, and
+ * what the wire wants is one thirty two bit word of the four. Putting them
+ * together here rather than writing them out that way in the header is what
+ * keeps this from depending on which end of a word this machine puts first.
+ *
+ * Nothing is premultiplied because nothing needs to be: every pixel of a GEM
+ * icon is either there or not, and a transparent one is written as no colour
+ * at all rather than as a colour nobody can see.
+ */
+static void icon_make(void)
+{
+    int multiples[ICON_SIZES];
+    struct wl_shm_pool *pool;
+    size_t bytes = 0;
+    size_t at = 0;
+    uint32_t *pixels;
+    int count, fd, i;
+
+    if (!w.icon_manager)
+        return;
+
+    count = icon_multiples(multiples);
+
+    for (i = 0; i < count; i++)
+    {
+        size_t side = (size_t)multiples[i] * WINDOW_ICON_SIZE;
+        bytes += side * side * 4;
+    }
+
+    fd = memfd_create("tosemu-icon", MFD_CLOEXEC);
+    if (fd < 0)
+        return;
+
+    if (ftruncate(fd, (off_t)bytes) < 0)
+    {
+        close(fd);
+        return;
+    }
+
+    pixels = mmap(0, bytes, PROT_READ|PROT_WRITE, MAP_SHARED, fd, 0);
+    if (pixels == MAP_FAILED)
+    {
+        close(fd);
+        return;
+    }
+
+    pool = wl_shm_create_pool(w.shm, fd, (int32_t)bytes);
+
+    for (i = 0; i < count; i++)
+    {
+        int scale = multiples[i];
+        int side = scale * WINDOW_ICON_SIZE;
+        uint32_t *out = pixels + at / 4;
+        int x, y;
+
+        for (y = 0; y < side; y++)
+        {
+            for (x = 0; x < side; x++)
+            {
+                const unsigned char *p = window_icon_argb
+                    + ((y / scale) * WINDOW_ICON_SIZE + x / scale) * 4;
+
+                out[y * side + x] = ((uint32_t)p[0] << 24)
+                                  | ((uint32_t)p[1] << 16)
+                                  | ((uint32_t)p[2] << 8)
+                                  |  (uint32_t)p[3];
+            }
+        }
+
+        w.icon_buffers[i] = wl_shm_pool_create_buffer(pool, (int32_t)at,
+                                                      side, side, side * 4,
+                                                      WL_SHM_FORMAT_ARGB8888);
+        at += (size_t)side * side * 4;
+    }
+
+    wl_shm_pool_destroy(pool);
+
+    /* The compositor has its own view of the file now, and the pool held the
+     * only reference this end needed to it */
+    munmap(pixels, bytes);
+    close(fd);
+
+    w.icon = xdg_toplevel_icon_manager_v1_create_icon(w.icon_manager);
+
+    /*
+     * Every one is offered at a scale of one, which is what says they are
+     * several sizes of the same icon rather than one size drawn for several
+     * displays. Which of them a doubled display ends up with is then the
+     * compositor's arithmetic rather than a guess made here.
+     */
+    for (i = 0; i < count; i++)
+        if (w.icon_buffers[i])
+            xdg_toplevel_icon_v1_add_buffer(w.icon, w.icon_buffers[i], 1);
 }
 
 /*
@@ -2463,6 +2703,21 @@ static int window_create(struct window *win, const char *title,
     xdg_toplevel_add_listener(win->toplevel, &toplevel_listener, win);
     xdg_toplevel_set_title(win->toplevel, title);
     xdg_toplevel_set_app_id(win->toplevel, "se.e8johan.tosemu");
+
+    /*
+     * And the picture that goes with the name. Without it a task bar has
+     * nothing to show and shows the compositor's placeholder, which is a
+     * Wayland mark - so a GEM application appeared in the window list under
+     * somebody else's logo.
+     *
+     * The app_id would be the other way to answer it, but only for a program
+     * with a desktop entry file installed somewhere a compositor looks. This
+     * one is run out of its build directory as often as not, and there is no
+     * entry file for the GEM application it is running in any case. See TODO.
+     */
+    if (w.icon)
+        xdg_toplevel_icon_manager_v1_set_icon(w.icon_manager, win->toplevel,
+                                              w.icon);
 
     /*
      * A window that has not said otherwise cannot be resized, which is the
@@ -2710,6 +2965,22 @@ int gfx_open(struct surface *screen)
 
     xdg_wm_base_add_listener(w.wm_base, &wm_base_listener, 0);
 
+    /*
+     * A second roundtrip, for what the compositor has to say about icons.
+     *
+     * It says it when the manager is bound, which happened during the first
+     * one - so the answer is on its way but has not arrived, and asking again
+     * is what waits for it. Everything else here was answered by the bind
+     * itself and needed no second question.
+     */
+    if (w.icon_manager)
+        wl_display_roundtrip(w.display);
+
+    /* Before any window is opened, because a window is given the icon as it is
+     * created and there is nothing here that would go back and fit one to a
+     * window that had already appeared without it */
+    icon_make();
+
     w.xkb = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 
     /*
@@ -2727,6 +2998,16 @@ void gfx_close()
 
     for (i = 0; i < WINDOWS; i++)
         window_destroy(&w.windows[i]);
+
+    /* After the windows, because a buffer the icon was built from is one the
+     * compositor is entitled to read for as long as a window still wears it */
+    if (w.icon)
+        xdg_toplevel_icon_v1_destroy(w.icon);
+    for (i = 0; i < ICON_SIZES; i++)
+        if (w.icon_buffers[i])
+            wl_buffer_destroy(w.icon_buffers[i]);
+    if (w.icon_manager)
+        xdg_toplevel_icon_manager_v1_destroy(w.icon_manager);
 
     if (w.xkb_state)
         xkb_state_unref(w.xkb_state);

--- a/src/icontest.c
+++ b/src/icontest.c
@@ -1,0 +1,189 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * The picture that goes on the windows.
+ *
+ * Host built for the same reason bin/screentest is: what happens to this
+ * picture afterwards is a compositor drawing it in a task bar, and a task bar
+ * is not something a test can arrange. What can be checked is what is handed
+ * over, and that is the whole of what could quietly go wrong here.
+ *
+ * Two things could. The picture is taken out of EmuTOS's icon resource by
+ * number, and the numbers belong to somebody else's tree - a resource with its
+ * icons in another order would put a folder or a floppy disk on every window
+ * and nothing would say so. And a resource is bits and masks rather than
+ * pixels, so a picture read out of one by the wrong end of a byte is a picture
+ * that is still the right size and still looks like an icon.
+ *
+ * So this asks whether the picture is the generic application icon: a window
+ * with a title bar, which is what EmuTOS draws for a program and what none of
+ * the icons either side of it in the file looks like.
+ */
+
+#include <stdio.h>
+
+/* The picture, as the build made it - see the rule in the Makefile */
+#include "rsc/window-icon.h"
+
+static int n;
+static int fails;
+
+static void check(long got, long want, const char *name)
+{
+    n++;
+    if (got == want)
+        printf("ok %d - %s\n", n, name);
+    else
+    {
+        fails++;
+        printf("not ok %d - %s (got %ld, want %ld)\n", n, name, got, want);
+    }
+}
+
+/* The same, for a pixel: a number would be the character's code, and "got 32,
+ * want 46" says nothing to anyone reading it out of a build log */
+static void check_pixel(int got, int want, const char *name)
+{
+    n++;
+    if (got == want)
+        printf("ok %d - %s\n", n, name);
+    else
+    {
+        fails++;
+        printf("not ok %d - %s (got %c, want %c)\n", n, name, got, want);
+    }
+}
+
+/*
+ * A pixel, as one of the three things a pixel of a GEM icon can be.
+ *
+ * There are only three. Where the icon's data says so it is ink, where its
+ * mask says so and its data does not it is paper, and where neither does it is
+ * the desktop showing through - which has to be no colour at all rather than a
+ * transparent black, because the wire wants a premultiplied pixel and a colour
+ * behind a zero alpha is not one.
+ */
+#define INK     ('#')
+#define PAPER   ('.')
+#define THROUGH (' ')
+#define WRONG   ('?')
+
+static int at(int x, int y)
+{
+    const unsigned char *p = window_icon_argb
+                             + ((size_t)y * WINDOW_ICON_SIZE + x) * 4;
+
+    if (p[0] == 0xff && p[1] == 0x00 && p[2] == 0x00 && p[3] == 0x00)
+        return INK;
+    if (p[0] == 0xff && p[1] == 0xff && p[2] == 0xff && p[3] == 0xff)
+        return PAPER;
+    if (p[0] == 0x00 && p[1] == 0x00 && p[2] == 0x00 && p[3] == 0x00)
+        return THROUGH;
+
+    return WRONG;
+}
+
+/* Whether a row is the same thing from one column to another */
+static int run(int y, int from, int to, int want)
+{
+    int x;
+
+    for (x = from; x <= to; x++)
+        if (at(x, y) != want)
+            return 0;
+
+    return 1;
+}
+
+/* And whether a row has any ink in it at all, which is what tells a title bar
+ * from the empty middle of a window */
+static int inked(int y)
+{
+    int x;
+
+    for (x = 0; x < WINDOW_ICON_SIZE; x++)
+        if (at(x, y) == INK)
+            return 1;
+
+    return 0;
+}
+
+static void picture(void)
+{
+    int size = WINDOW_ICON_SIZE;
+    int y, colours = 0;
+
+    /* The size is the protocol's business as much as the picture's: an icon
+     * buffer has to be square, and every size offered is a whole number of
+     * copies of this one */
+    check(size, 32, "the icon is the size an ST icon was drawn at");
+
+    for (y = 0; y < size; y++)
+    {
+        int x;
+
+        for (x = 0; x < size; x++)
+            if (at(x, y) == WRONG)
+                colours++;
+    }
+    check(colours, 0, "and is drawn in ink, paper and nothing else");
+
+    /* A corner of a GEM icon is outside its mask, which is what makes it a
+     * shape on the desktop rather than a square */
+    check_pixel(at(0, 0), THROUGH,
+                "its corners are the desktop showing through");
+    check_pixel(at(size - 1, size - 1), THROUGH, "at the far end as well");
+
+    /*
+     * And what is between them is a window drawn as tall as the picture. That
+     * is already most of the answer: the icons either side of this one in the
+     * file are a folder and a document, and both of them start several rows
+     * down - a folder to leave room for its tab and a document for its turned
+     * corner - so their top row is nothing at all where this one is drawn.
+     */
+    check_pixel(at(2, 0), PAPER,
+                "the picture is drawn to the top of the square");
+    check(run(1, 2, size - 3, INK), 1, "where the top of the window is");
+    check(run(size - 2, 2, size - 3, INK), 1, "and to the bottom of it");
+
+    check_pixel(at(1, size / 2), INK, "the left side of the window is drawn");
+    check_pixel(at(size - 2, size / 2), INK, "and the right side");
+    check(run(size / 2, 2, size - 3, PAPER), 1, "with paper between them");
+
+    /*
+     * And the title bar across the top of it, which is the rest of the answer:
+     * a line ruled the whole width of the window five rows down, something
+     * drawn above it and nothing below. Neither of the icons either side has
+     * anything of the sort.
+     */
+    check(inked(3), 1, "there is a title bar under the top");
+    check(run(5, 1, size - 2, INK), 1, "with a line ruled under it");
+    check(run(7, 2, size - 3, PAPER), 1, "and the empty window below that");
+}
+
+int main(void)
+{
+    picture();
+
+    printf("1..%d\n", n);
+
+    return fails ? 1 : 0;
+}

--- a/src/rsc/README
+++ b/src/rsc/README
@@ -1,6 +1,13 @@
 rsc - pictures
 ==============
 
+Two pictures, and neither of them is on the emulated screen. One is the mark
+tosaesd puts in the panel, which is tosemu's own; the other is what a task bar
+shows beside a window, which is EmuTOS's and is not kept here at all.
+
+The mark in the panel
+---------------------
+
 tray.svg is the mark that goes in the panel. Replace it with the real thing
 and run make; nothing else has to change.
 
@@ -37,3 +44,29 @@ mark drawn by the script instead, because needing a particular tool installed
 to build an emulator would be a poor trade for a nicer icon.
 
 Do not edit tray-icon.h. Edit the picture.
+
+The picture on the windows
+--------------------------
+
+There is no file here for that one, and there should not be. It is EmuTOS's
+generic application icon, and it is read out of the icon resource EmuTOS ships
+in the submodule - 3rdparty/emutos/extras/emuicon1.rsc, where it is icon number
+six, the number the EmuTOS desktop knows as IG_APPL. emuicon-to-c.py digs it
+out and writes window-icon.h next to tray-icon.h, and gfx.c puts it on every
+window it opens.
+
+Taking it rather than copying it is the point. It is somebody else's picture
+and the submodule is where it lives; a copy here would be a second one to keep
+up to date, and nothing would say when the two had drifted apart. What guards
+against the resource being renumbered under it is bin/icontest, which asks
+whether the picture that came out is still a window with a title bar.
+
+It is one thirty two pixel picture and no other size. A compositor says what
+sizes it would like and gfx.c answers with whole multiples of that one, made by
+repeating pixels - the same magnifying the emulated screen gets, and for the
+same reason. Making the sizes here instead would mean guessing them before the
+compositor had been asked.
+
+To use a different set, point the Makefile rule at emuicon0.rsc or emuicon2.rsc
+instead; they are the same icons in the same order, drawn by other people. See
+3rdparty/emutos/extras/readme.txt.

--- a/src/rsc/emuicon-to-c.py
+++ b/src/rsc/emuicon-to-c.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+#
+# TOSEMU - an emulated environment for TOS applications
+# Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+"""Turns one icon out of an EmuTOS icon resource into the C array a
+compositor is handed.
+
+A window of tosemu's is a window of a GEM application, and what a task bar
+should show beside its name is the picture the desktop it came from would have
+shown: EmuTOS's generic application icon.  Nothing else here can supply that.
+An icon theme has never heard of the program, and a desktop entry file would
+have to be installed before the icons meant anything - which is a thing an
+emulator run out of its build directory cannot rely on.
+
+So the picture is taken from the resource the EmuTOS desktop reads its own
+icons from and compiled in, the same bargain rsc/icon-to-c.py makes for the
+tray: a picture that is part of the program cannot go missing.
+
+Only the one size is written out, which is the size the icon was drawn at.
+What a compositor asks for is not known until it has been asked, and making it
+larger is repeating pixels rather than resampling them - so gfx.c does that at
+the sizes it turns out to want.  See icon_make there.
+"""
+
+import struct
+import sys
+
+# An icon is black on white paper, which is how the mono desktop drew it and
+# what makes it legible on a pale panel and a dark one alike.  Drawing the ink
+# and leaving the paper transparent would put black on black half the time.
+INK = (0x00, 0x00, 0x00)
+PAPER = (0xff, 0xff, 0xff)
+
+# The resource header, and the ICONBLK: three file offsets standing in for the
+# mask, the data and the name, then the eleven words of the ICONBLK proper.
+# See rsdefs.h and obdefs.h in EmuTOS.
+RSHDR = ">10H8h"
+ICONBLK = ">3I11h"
+ICONBLK_SIZE = 34
+
+
+def icon(rsc, index):
+    """The mask, the data and the size of one icon in a resource file."""
+    d = open(rsc, "rb").read()
+
+    hdr = struct.unpack(RSHDR, d[:struct.calcsize(RSHDR)])
+    iconblk, nib = hdr[3], hdr[13]
+
+    if index >= nib:
+        sys.exit("emuicon-to-c.py: %s holds %d icons, so there is no %d"
+                 % (rsc, nib, index))
+
+    at = iconblk + index * ICONBLK_SIZE
+    fields = struct.unpack(ICONBLK, d[at:at + ICONBLK_SIZE])
+    pmask, pdata, ptext = fields[0], fields[1], fields[2]
+    width, height = fields[8], fields[9]
+
+    if width % 8:
+        sys.exit("emuicon-to-c.py: icon %d in %s is %d pixels wide, which is "
+                 "not a whole number of bytes" % (index, rsc, width))
+
+    # A window icon has to be square, which is the protocol's requirement and
+    # not this file's - a compositor hands back an invalid_buffer error for
+    # anything else, and it would arrive at run time on somebody's desktop
+    if width != height:
+        sys.exit("emuicon-to-c.py: icon %d in %s is %dx%d, and a window icon "
+                 "has to be square" % (index, rsc, width, height))
+
+    # An icon's name is only ever read to say which picture was taken, which
+    # is worth saying: the index is a number in a Makefile and the name is not
+    name = d[ptext:d.index(b"\0", ptext)].decode("latin-1")
+    span = (width // 8) * height
+
+    return (d[pmask:pmask + span], d[pdata:pdata + span], width, height, name)
+
+
+def argb(mask, data, width, height):
+    """The icon as the pixels the wire wants.
+
+    A row of a GEM icon is bits, most significant first, and both halves are
+    read together: a bit of the data is ink, a bit of the mask with no data
+    under it is paper, and neither is the desktop showing through.
+    """
+    out = bytearray()
+    stride = width // 8
+
+    for y in range(height):
+        for x in range(width):
+            bit = 0x80 >> (x % 8)
+            byte = y * stride + x // 8
+
+            if data[byte] & bit:
+                out += bytes((0xff,) + INK)
+            elif mask[byte] & bit:
+                out += bytes((0xff,) + PAPER)
+            else:
+                out += b"\0\0\0\0"
+
+    return bytes(out)
+
+
+def main():
+    if len(sys.argv) != 4:
+        sys.exit("usage: emuicon-to-c.py <emuicon.rsc> <icon> <where.h>")
+
+    rsc, index, out = sys.argv[1], int(sys.argv[2], 0), sys.argv[3]
+    mask, data, width, height, name = icon(rsc, index)
+    pixels = argb(mask, data, width, height)
+
+    with open(out, "w") as f:
+        f.write("/*\n"
+                " * The window icon, as pixels: alpha, red, green and blue,\n"
+                " * a row at a time.\n"
+                " *\n"
+                " * Generated from icon %d (%s) of\n"
+                " * %s by rsc/emuicon-to-c.py.\n"
+                " * Do not edit this - the picture is EmuTOS's and belongs to\n"
+                " * the submodule.  See src/rsc/README.\n"
+                " */\n\n" % (index, name, rsc))
+
+        f.write("#define WINDOW_ICON_SIZE %d\n\n" % width)
+        f.write("static const unsigned char window_icon_argb[] = {\n")
+        for chunk in range(0, len(pixels), 12):
+            f.write("    " + " ".join("0x%02x," % b
+                                      for b in pixels[chunk:chunk + 12]) + "\n")
+        f.write("};\n")
+
+    print("emuicon-to-c.py: %s icon %d (%s) -> %s (%dx%d)"
+          % (rsc, index, name, out, width, height))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A task bar and a window switcher show a picture beside a window's name, and tosemu gave them nothing to show. What appeared instead was whatever the compositor puts there when it has nothing - on KDE a Wayland mark - so a GEM application sat in the window list under somebody else's logo, and every window of every program looked identical to every other.

Nobody had noticed because the windows already carried an app_id, which is the half of this that needs no files, and an app_id is enough for a compositor to group windows and keep them apart. It is not enough to find a picture: that route goes through a desktop entry file installed somewhere the compositor looks, and there is none for tosemu - which is run out of its build directory as often as not - nor for the GEM application it is running.

So the picture is handed over directly, which is what xdg-toplevel-icon-v1 is for, and the picture is EmuTOS's generic application icon: what the desktop these programs were written for would have shown for a program that never said it had one of its own. It is read out of the icon resource EmuTOS ships in the submodule rather than copied into this tree, so there is one copy of it and the submodule goes on owning it.

The compositor says what sizes it would like and gets whole multiples of the thirty two pixel picture, made by repeating pixels. That is the same magnifying the emulated screen gets and for the same reason: an ST pixel is a large old pixel, and resampling one to a size that is not a whole number of them is the smoothing the rest of gfx.c exists to avoid. KDE asks for ninety six, which is three of them exactly.

bin/icontest checks the half of this a test can reach - that the picture which came out of somebody else's resource file is still a window with a title bar, and not the folder or the document either side of it should EmuTOS ever renumber its icons.