### PR TITLE
AES: a timer of no time at all was read as no timer

### DIFF
--- a/src/aesevnt.c
+++ b/src/aesevnt.c
@@ -132,9 +132,10 @@ static long now_ms()
 /*
  * Waits until one of the things asked for happens, and says which.
  *
- * timeout is in milliseconds, or -1 to wait for as long as it takes. A
- * timeout of zero is a GEM idiom meaning "wait for ever" when MU_TIMER is
- * asked for, and the caller has already turned that into -1.
+ * timeout is in milliseconds, or -1 to wait for as long as it takes. A timeout
+ * of zero is a timer that has already expired: everything else is looked at
+ * once and then MU_TIMER is the answer, which is how an application asks what
+ * has happened without agreeing to wait for anything.
  */
 /* Whether the pointer is inside a rectangle, or outside it, which is the two
  * things a mouse rectangle event can be waiting for */
@@ -637,12 +638,18 @@ uint32_t AES_evnt_multi()
         printf("    wanted: 0x%x, timer: %ld ms\n", wanted, ms);
     }
 
-    /* A timer of zero milliseconds means no timer at all rather than one that
-     * has already expired */
-    if (!(wanted & MU_TIMER) || ms == 0)
-        timeout = -1;
-    else
+    /*
+     * A timer of zero milliseconds is one that has already expired, so the
+     * wait looks at everything else once and comes straight back with
+     * MU_TIMER. That is how an application asks what has happened without
+     * agreeing to wait for anything, and reading it as "no timer" - which
+     * leaves the wait with nothing but the message queue to end it - is a
+     * program that polls being stopped dead at the first poll.
+     */
+    if (wanted & MU_TIMER)
         timeout = ms;
+    else
+        timeout = -1;
 
     /* The two rectangles, which MU_M1 and MU_M2 wait for the pointer to enter
      * or to leave. The flag before each says which of the two. */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,12 +19,12 @@
 STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal \
           Fopen Fclose Fread Supexec Dcreate Fcreate Fwrite Fdelete Fattrib \
           cmdline Malloc
-CTESTNAME=c-helloworld c-drives c-bios c-xbios c-mxalloc c-memory c-pexec c-pexchild c-overlay c-gem c-vdi c-aesd c-acc c-userdef c-icon c-boxchar c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-scrap
+CTESTNAME=c-helloworld c-drives c-bios c-xbios c-mxalloc c-memory c-pexec c-pexchild c-overlay c-gem c-vdi c-aesd c-acc c-userdef c-icon c-boxchar c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-scrap c-poll
 
 # The ones that call the AES or the VDI, whose bindings live in their own
 # library rather than in the C one
 GEMTESTNAME=c-gem c-vdi c-aesd c-scrap c-acc c-userdef c-icon c-boxchar c-fsel \
-            c-watchbox c-mkstate c-screen c-menu c-frame c-resize
+            c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-poll
 
 # Where the sources are, found through the makefile that was read rather than
 # from the directory make happens to be standing in, since it is standing in
@@ -328,6 +328,12 @@ check: all
 	# then pressed and not let go of, and none of it is waited for.
 	TOSEMU_CLICKS='@100,60 @150,80 !200,100' $(TOSEMU) test-c-mkstate > out; \
 	  ! grep -q '^not ok' out
+	grep -q '^1\.\.' out
+	# Asking what has happened without agreeing to wait for it, which is a
+	# timer of nought milliseconds on a wait. Nothing is injected: with no
+	# compositor the timer is the only thing that can end one, so a wait
+	# that blocks stops the emulator and the count line goes missing.
+	$(TOSEMU) test-c-poll > out; ! grep -q '^not ok' out
 	grep -q '^1\.\.' out
 	# Pexec 200 leaves test-Pterm running in its place, which returns 42
 	$(TOSEMU) test-c-overlay; test "$$?" = 42

--- a/tests/c-poll.c
+++ b/tests/c-poll.c
@@ -1,0 +1,104 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * Asking what has happened without agreeing to wait for it.
+ *
+ * evnt_multi is how an application waits, and a timer of nought milliseconds
+ * is how it asks the same question without waiting: the timer has already
+ * expired, so everything else is looked at once and the answer comes straight
+ * back as MU_TIMER. The AES does that in the quick checks at the top of
+ * ev_multi, before it blocks for anything - see 3rdparty/emutos/aes/gemevlib.c.
+ *
+ * Reading the nought as "no timer at all" instead leaves the wait with only
+ * the message queue to end it, and an application that polls stops dead at its
+ * first poll with nothing on screen to say why. Atari Works is the case that
+ * showed it: picking New from its opening dialog puts up the busy bee and
+ * polls for the work it queued behind it, so the document window never
+ * appeared and the menu bar never answered, the application never having got
+ * back out of the poll to hear about either.
+ *
+ * A timer with a real interval on it still waits, and it is here so that
+ * making the nought come back at once cannot be done by making every timer
+ * come back at once.
+ *
+ * These run with no compositor, so nothing but the timer can ever end a wait.
+ * A wait that blocks stops the emulator, which then prints nothing further -
+ * so the count at the end is what says the whole file ran.
+ */
+
+#include <stdio.h>
+#include <gem.h>
+
+static int n;
+
+static void check(long got, long want, const char *name)
+{
+    n++;
+    if (got == want)
+        printf("ok %d - %s\n", n, name);
+    else
+        printf("not ok %d - %s (got %ld, want %ld)\n", n, name, got, want);
+}
+
+/* What a wait is asked for and told, which is the same every time here */
+static short poll_for(unsigned long ms)
+{
+    short message[8];
+    short mx = 0, my = 0, mb = 0, ks = 0, kr = 0, br = 0;
+
+    return evnt_multi(MU_TIMER | MU_MESAG, 0, 0, 0,
+                      0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0,
+                      message, ms,
+                      &mx, &my, &mb, &ks, &kr, &br);
+}
+
+int main(int argc, char **argv)
+{
+    if (appl_init() < 0)
+    {
+        printf("Bail out! - no AES to talk to\n");
+        return 1;
+    }
+
+    /* The near neighbour, and the one that was already right: evnt_timer of
+     * nought is not a wait either */
+    evnt_timer(0);
+    check(1, 1, "evnt_timer of no time at all comes back");
+
+    check(poll_for(0), MU_TIMER,
+          "a timer of no time at all has already expired");
+
+    /*
+     * Twice, because polling is what an application does in a loop. One poll
+     * that answers and a second that blocks is the same hang arriving later.
+     */
+    check(poll_for(0), MU_TIMER, "and it answers the same the next time round");
+
+    /* An interval is still an interval: this one has to wait for it */
+    check(poll_for(200), MU_TIMER, "a timer with an interval on it still ends");
+
+    printf("1..%d\n", n);
+
+    appl_exit();
+
+    return 0;
+}


### PR DESCRIPTION
evnt_multi took a timer of nought milliseconds to mean that no timer had been asked for, and turned the wait into one with no deadline. GEM means the opposite: the timer has already expired, so the AES looks at everything else once and answers MU_TIMER straight away. That is the quick check at the top of ev_multi in 3rdparty/emutos/aes/gemevlib.c, and it runs before the AES blocks for anything.

So an application asking what had happened without agreeing to wait for it was made to wait for a message instead, and the only thing that could end the wait was one arriving. An application that polls stops dead at its first poll, with nothing on the screen to say why.

Nobody had noticed because a poll is a shape the tests did not have and the applications tried so far do not use: a program that waits for the keyboard, the mouse or a message is asking for something that arrives, and every one of those went on working. Atari Works is the case that showed it. Picking New from its opening dialog puts up the busy bee and polls for the work queued behind the dialog, so the document window never appeared - and the menu bar never answered either, the application never having got back out of the poll to hear about a selection.

The wait already answers MU_TIMER when the deadline has passed, so passing the nought through is the whole of the fix: one pass over the menu bar, the message queue, the keyboard and the buttons, and then the timer. The same rule was already right on the other side of the seam - aeskernel.c hands the count through for the AES's own waits - so it was only the trap an application enters that had it wrong.

tests/c-poll.c is the check. It runs with no compositor, where nothing but a timer can ever end a wait, so a poll that blocks stops the emulator and takes the count line with it.