### PR TITLE
Attempt to fix flashing menus under Mutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ wait that answers wrongly is invisible from anywhere else: two different waits
 asking the same question and one wait asking it twice look identical until
 something says which happened.
 
+It also says which window the pointer arrived in and left, and whether a menu
+that went away went away because the desktop took it. Those are the same
+question asked of the desktop rather than of the application: a menu closing
+by itself is either the AES deciding to close it or the compositor deciding
+for us, and from a screen the two look identical. Which desktop is running
+decides which it was, so this is the first thing to ask when a menu behaves
+differently on two of them.
+
 Set `TOSEMU_SCREENSHOT` to a path and the screen is written there as a
 portable pixmap every time an application waits, which is how to look at what
 was drawn from a terminal, or from a test, or without a desktop at all.

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -1068,6 +1068,21 @@ static struct window *window_of(struct wl_surface *surface)
     return 0;
 }
 
+/* What to call a window when saying what the pointer did to it */
+static const char *window_called(struct window *win)
+{
+    if (!win)
+        return "nothing of ours";
+    if (win == &w.windows[MENUBAR])
+        return "the menu bar";
+    if (win == &w.windows[MENU])
+        return "the menu";
+    if (win == &w.windows[DIALOG])
+        return "the dialog";
+
+    return "a window";
+}
+
 /*
  * Where the pointer is, in the screen's own pixels.
  *
@@ -1153,12 +1168,20 @@ static void pt_enter(void *data, struct wl_pointer *p, uint32_t serial,
     w.serial = serial;
     w.pointer_in = window_of(s);
     pointer_at(w.pointer_in, x, y);
+
+    if (setting_flag("TOSEMU_TRACE_INPUT"))
+        printf("tosemu: the pointer arrived in %s\n",
+               window_called(w.pointer_in));
 }
 
 static void pt_leave(void *data, struct wl_pointer *p, uint32_t serial,
                      struct wl_surface *s)
 {
     (void)data; (void)p; (void)serial;
+
+    if (setting_flag("TOSEMU_TRACE_INPUT"))
+        printf("tosemu: the pointer left %s%s\n", window_called(window_of(s)),
+               w.pressed ? ", with a button held down" : "");
 
     /*
      * Only if it is the window the pointer is actually in.
@@ -2726,6 +2749,10 @@ static void popup_done(void *data, struct xdg_popup *popup)
     (void)popup;
 
     win->gone = 1;
+
+    if (setting_flag("TOSEMU_TRACE_INPUT"))
+        printf("tosemu: the desktop took the menu away, with the pointer in "
+               "%s\n", window_called(w.pointer_in));
 
     /*
      * Unless nobody clicked outside it, which is a different thing altogether.

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -355,6 +355,10 @@ static struct {
      * screen's coordinates rather than in that window's */
     struct window *pointer_in;
 
+    /* And whether it left one with something held down, which is not the same
+     * as the person letting go of it. See pointer_settle. */
+    int left_holding;
+
     /*
      * And whether it is on the strip that window drew for itself, with how far
      * along it in that window's own pixels.
@@ -550,6 +554,52 @@ int gfx_key_take(uint16_t *key)
 }
 
 /*
+ * The button coming up because the pointer went away, once it is certain that
+ * it did go away.
+ *
+ * A window losing the pointer is not always the pointer leaving. Crossing from
+ * the menu bar into the menu hanging off it is a leave and then an enter, and
+ * on a desktop that hands the pointer to whichever of our surfaces it is over
+ * while a menu is up - GNOME's does, KDE's keeps it in the window the button
+ * was pressed in - the pair arrives in the middle of pulling a menu down, with
+ * the button still held. Answering the leave where it happens puts a release
+ * in the queue that nobody performed, and a release is what ends a menu: the
+ * menu closes as the pointer crosses the line between the bar and itself.
+ *
+ * So the release waits until something asks what the mouse is doing. By then
+ * everything the compositor had to say has been read and the enter that
+ * followed, if there was one, has been seen - and a pointer that arrived
+ * somewhere else of ours never left. Only one that landed nowhere has really
+ * gone, and only that one lets go.
+ */
+static void pointer_settle(void)
+{
+#ifndef NO_WAYLAND
+    if (!w.left_holding)
+        return;
+
+    w.left_holding = 0;
+
+    if (w.pointer_in)
+        return;
+
+    if (!w.pressed && !w.buttons)
+        return;
+
+    w.pressed = 0;
+
+    if (w.click_count < (int)(sizeof w.clicks / sizeof w.clicks[0]))
+    {
+        w.clicks[w.click_count].buttons = 0;
+        w.clicks[w.click_count].x = w.mouse_x;
+        w.clicks[w.click_count].y = w.mouse_y;
+        w.clicks[w.click_count].move = 0;
+        w.click_count++;
+    }
+#endif
+}
+
+/*
  * Where the pointer is and what is held down, as of the last change anybody
  * took off the queue.
  *
@@ -561,6 +611,7 @@ int gfx_key_take(uint16_t *key)
 void gfx_mouse(int16_t *x, int16_t *y, int16_t *buttons)
 {
     clicks_from_environment();
+    pointer_settle();
 
     *x = w.mouse_x;
     *y = w.mouse_y;
@@ -596,6 +647,7 @@ void gfx_mouse_now(int16_t *x, int16_t *y, int16_t *buttons)
     /* An application that polls never reaches the event loop, so this is the
      * only place its idea of where the pointer is can catch up */
     gfx_dispatch_ready();
+    pointer_settle();
 
     *x = w.mouse_x;
     *y = w.mouse_y;
@@ -761,6 +813,7 @@ int gfx_motion_take(void)
     int i;
 
     clicks_from_environment();
+    pointer_settle();
 
     if (w.click_count == 0 || !w.clicks[0].move)
         return 0;
@@ -787,6 +840,7 @@ int gfx_motion_take(void)
 int gfx_button_peek(int16_t *buttons, int16_t *x, int16_t *y)
 {
     clicks_from_environment();
+    pointer_settle();
 
     if (w.click_count == 0 || w.clicks[0].move)
         return 0;
@@ -803,6 +857,7 @@ int gfx_button_take(int16_t *buttons, int16_t *x, int16_t *y)
     int i;
 
     clicks_from_environment();
+    pointer_settle();
 
     if (w.click_count == 0 || w.clicks[0].move)
         return 0;
@@ -991,6 +1046,10 @@ static struct window *window_of(struct wl_surface *surface)
  * So the button comes up. That is not a guess about what the person did - it
  * is the honest answer, which is that we no longer know and will not pretend
  * otherwise. If it really is still held, the enter that follows says so.
+ *
+ * Which is why it is written down here and answered elsewhere. A window losing
+ * the pointer to another of our own windows is not the pointer going anywhere,
+ * and the enter saying so arrives after this. See pointer_settle.
  */
 static void pointer_gone(void)
 {
@@ -1000,16 +1059,7 @@ static void pointer_gone(void)
     if (!w.pressed && !w.buttons)
         return;
 
-    w.pressed = 0;
-
-    if (w.click_count < (int)(sizeof w.clicks / sizeof w.clicks[0]))
-    {
-        w.clicks[w.click_count].buttons = 0;
-        w.clicks[w.click_count].x = w.mouse_x;
-        w.clicks[w.click_count].y = w.mouse_y;
-        w.clicks[w.click_count].move = 0;
-        w.click_count++;
-    }
+    w.left_holding = 1;
 }
 
 static void pointer_at(struct window *win, wl_fixed_t x, wl_fixed_t y)

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -381,6 +381,19 @@ static struct {
      */
     uint32_t serial;
 
+    /*
+     * And the last one that was something being pressed, which is not the same
+     * question.
+     *
+     * A grab has to answer a press or a keystroke in particular, and a
+     * compositor is entitled to check which: the pointer arriving in a window
+     * is something that happened to the person rather than something they did.
+     * Some desktops take whatever they are given and some refuse anything but
+     * the serial of the press they are still in the middle of - which is why a
+     * menu that works on one comes straight back down on another.
+     */
+    uint32_t press_serial;
+
     struct surface *screen;
 
     /* Keys waiting to be read, oldest first */
@@ -958,6 +971,10 @@ static void kb_key(void *data, struct wl_keyboard *kb, uint32_t serial,
     if (state != WL_KEYBOARD_KEY_STATE_PRESSED || !w.xkb_state)
         return;
 
+    /* A key going down is one of the things a grab may answer, the same way a
+     * button going down is */
+    w.press_serial = serial;
+
     sym = xkb_state_key_get_one_sym(w.xkb_state, code);
 
     /*
@@ -1151,6 +1168,11 @@ static void pt_button(void *data, struct wl_pointer *p, uint32_t serial,
     (void)data; (void)p; (void)time;
 
     w.serial = serial;
+
+    /* And the one a grab has to answer, which is a press rather than any of
+     * the other things that carry a serial */
+    if (state == WL_POINTER_BUTTON_STATE_PRESSED)
+        w.press_serial = serial;
 
     /* GEM numbers them from the left, and has two */
     switch (button)
@@ -2196,14 +2218,14 @@ static void frame_press(struct window *win, int16_t buttons)
         return;
     }
 
-    /* Both of the rest have to be answering something the person did, and the
-     * serial of that is what proves it. There is nothing to answer when the
-     * input was made up rather than done, which is what happens under a test. */
-    if (!win->toplevel || !w.seat || !w.serial)
+    /* Both of the rest have to be answering the press this is, and the serial
+     * of that is what proves it. There is nothing to answer when the input was
+     * made up rather than done, which is what happens under a test. */
+    if (!win->toplevel || !w.seat || !w.press_serial)
         return;
 
     if (buttons == 2)
-        xdg_toplevel_show_window_menu(win->toplevel, w.seat, w.serial,
+        xdg_toplevel_show_window_menu(win->toplevel, w.seat, w.press_serial,
                                       w.frame_x, w.frame_y);
     /*
      * The size box on the end of the menu bar, which is at the very edge of it.
@@ -2217,10 +2239,10 @@ static void frame_press(struct window *win, int16_t buttons)
      */
     else if (win->frame_w
              && w.frame_x >= (win->sw + win->frame_w - wbox) * win->scale)
-        xdg_toplevel_resize(win->toplevel, w.seat, w.serial,
+        xdg_toplevel_resize(win->toplevel, w.seat, w.press_serial,
                             XDG_TOPLEVEL_RESIZE_EDGE_RIGHT);
     else
-        xdg_toplevel_move(win->toplevel, w.seat, w.serial);
+        xdg_toplevel_move(win->toplevel, w.seat, w.press_serial);
 
     wl_display_flush(w.display);
 }
@@ -3237,9 +3259,12 @@ void gfx_window_limits(int16_t handle, int16_t min_w, int16_t min_h,
  * the drag the person would have got by taking hold of a corner, and what
  * comes back is a configure saying how large the window has become.
  *
- * It has to be answering something the person did, and the serial of that is
- * what proves it. There is nothing to answer when the input was made up rather
- * than done, which is what happens under a test.
+ * It has to be answering the press that started it, and the serial of that is
+ * what proves it. The press in particular, rather than the last thing of any
+ * kind: a compositor that checks wants the one it is still in the middle of,
+ * and the pointer arriving in a window carries a serial too. There is nothing
+ * to answer at all when the input was made up rather than done, which is what
+ * happens under a test.
  */
 void gfx_window_drag_size(int16_t handle)
 {
@@ -3249,10 +3274,10 @@ void gfx_window_drag_size(int16_t handle)
         return;
 
     win = &w.windows[handle];
-    if (!win->used || !win->toplevel || !w.seat || !w.serial)
+    if (!win->used || !win->toplevel || !w.seat || !w.press_serial)
         return;
 
-    xdg_toplevel_resize(win->toplevel, w.seat, w.serial,
+    xdg_toplevel_resize(win->toplevel, w.seat, w.press_serial,
                         XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT);
     wl_display_flush(w.display);
 }
@@ -3274,10 +3299,10 @@ void gfx_window_drag_move(int16_t handle)
         return;
 
     win = &w.windows[handle];
-    if (!win->used || !win->toplevel || !w.seat || !w.serial)
+    if (!win->used || !win->toplevel || !w.seat || !w.press_serial)
         return;
 
-    xdg_toplevel_move(win->toplevel, w.seat, w.serial);
+    xdg_toplevel_move(win->toplevel, w.seat, w.press_serial);
     wl_display_flush(w.display);
 }
 
@@ -3302,10 +3327,10 @@ void gfx_window_menu(int16_t handle, int16_t x, int16_t y)
         return;
 
     win = &w.windows[handle];
-    if (!win->used || !win->toplevel || !w.seat || !w.serial)
+    if (!win->used || !win->toplevel || !w.seat || !w.press_serial)
         return;
 
-    xdg_toplevel_show_window_menu(win->toplevel, w.seat, w.serial,
+    xdg_toplevel_show_window_menu(win->toplevel, w.seat, w.press_serial,
                                   (x - win->sx) * win->scale,
                                   (y - win->sy + win->frame_h) * win->scale);
     wl_display_flush(w.display);
@@ -3429,9 +3454,17 @@ void gfx_menu_open(struct surface *shows, int16_t x, int16_t y,
      * nothing to answer when the input was made up rather than done, which is
      * what happens under a test. Asking anyway would have the menu dismissed
      * the moment it appeared.
+     *
+     * A press is what it wants to be answering, and a compositor that checks
+     * will take nothing else - so the last press is offered before the last
+     * thing of any kind. A GEM menu opens when the pointer arrives among the
+     * titles rather than when anything is pressed, so the press being answered
+     * is whatever the person did last, which is the best there is: what the
+     * menu is answering happened, and it was not a click.
      */
-    if (w.seat && w.serial)
-        xdg_popup_grab(win->popup, w.seat, w.serial);
+    if (w.seat && (w.press_serial || w.serial))
+        xdg_popup_grab(win->popup, w.seat,
+                       w.press_serial ? w.press_serial : w.serial);
 
     wl_surface_commit(win->surface);
     wl_display_roundtrip(w.display);

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -1046,12 +1046,23 @@ static const struct wl_keyboard_listener keyboard_listener = {
 
 /* Pointer *****************************************************************/
 
+/*
+ * Whose surface that is.
+ *
+ * A window is asked about by its surface rather than by whether it is finished,
+ * and the difference is a real one: a window is made, told what it is and
+ * committed before it has a buffer, and the compositor may say the pointer is
+ * in it during the round trip that waits for the first configure. A menu drops
+ * down under the pointer, so that is not a rare ordering - and an enter nobody
+ * recognised leaves the pointer belonging to nothing, with every move it makes
+ * afterwards thrown away until it leaves and comes back.
+ */
 static struct window *window_of(struct wl_surface *surface)
 {
     int i;
 
     for (i = 0; i < WINDOWS; i++)
-        if (w.windows[i].used && w.windows[i].surface == surface)
+        if (w.windows[i].surface && w.windows[i].surface == surface)
             return &w.windows[i];
 
     return 0;

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -280,6 +280,10 @@ struct window {
 
     /* The compositor dismissed it, which only happens to menus */
     int gone;
+
+    /* Whether it asked to take the pointer, which only a menu does. What it
+     * settles is what being dismissed means - see popup_done. */
+    int grabbed;
 };
 
 /*
@@ -440,6 +444,20 @@ static struct {
 
     int closed;
     int showing;
+
+    /*
+     * A menu taken away by a compositor that would not let it have the
+     * pointer, which is a menu to put back rather than one to put away, and
+     * whether that has happened at all.
+     *
+     * The second is asked once and answered for the rest of the run. A
+     * desktop that refuses one menu the pointer refuses every menu the
+     * pointer, and asking each time costs a menu that appears and vanishes
+     * before it can be used. See popup_done, and gfx_present, where the menu
+     * is put back.
+     */
+    int menu_refused;
+    int menu_grab_refused;
 } w;
 
 /* Input *******************************************************************/
@@ -2699,6 +2717,28 @@ static void popup_done(void *data, struct xdg_popup *popup)
     win->gone = 1;
 
     /*
+     * Unless nobody clicked outside it, which is a different thing altogether.
+     *
+     * A menu is taken away when something outside it is pressed, and nothing
+     * outside it can be pressed without the pointer having left our windows
+     * first. So a menu taken away while the pointer is still in one of them
+     * was not taken away by the person: it is a compositor refusing the grab
+     * the menu asked for, which some do when the thing being answered is not a
+     * press of their choosing.
+     *
+     * A menu that may not have the pointer is worth having anyway - what is
+     * lost is being told about a click that lands somewhere else - so it goes
+     * back up without asking for one. Only the menu that asked can be refused,
+     * so the one that goes back up cannot start this again.
+     */
+    if (win->grabbed && w.pointer_in)
+    {
+        w.menu_refused = 1;
+        w.menu_grab_refused = 1;
+        return;
+    }
+
+    /*
      * The compositor took the menu away, which is what it does when something
      * outside it is clicked. The AES has no idea: the click was never ours to
      * see, which is the whole reason for the grab.
@@ -3461,10 +3501,16 @@ void gfx_menu_open(struct surface *shows, int16_t x, int16_t y,
      * titles rather than when anything is pressed, so the press being answered
      * is whatever the person did last, which is the best there is: what the
      * menu is answering happened, and it was not a click.
+     *
+     * Refused anyway, the menu goes back up without a grab rather than being
+     * taken for one the person dismissed. See popup_done.
      */
-    if (w.seat && (w.press_serial || w.serial))
+    if (w.seat && (w.press_serial || w.serial) && !w.menu_grab_refused)
+    {
         xdg_popup_grab(win->popup, w.seat,
                        w.press_serial ? w.press_serial : w.serial);
+        win->grabbed = 1;
+    }
 
     wl_surface_commit(win->surface);
     wl_display_roundtrip(w.display);
@@ -4009,7 +4055,27 @@ void gfx_present()
      * is watching the pointer itself and will come to the same conclusion in
      * its own time; this is only the window going. */
     if (w.windows[MENU].gone)
+    {
+        /*
+         * Unless it was taken away for asking to have the pointer, in which
+         * case the AES has not concluded anything and the menu is still down
+         * as far as it is concerned. Putting it back is what agrees with that,
+         * and it goes back without asking a second time - see popup_done.
+         *
+         * Here rather than where the compositor said so, because opening a
+         * window waits for the compositor to answer and that cannot be done in
+         * the middle of reading what it has already said.
+         */
+        struct window again = w.windows[MENU];
+
         gfx_menu_close();
+
+        if (w.menu_refused)
+        {
+            w.menu_refused = 0;
+            gfx_menu_open(again.shows, again.sx, again.sy, again.sw, again.sh);
+        }
+    }
 
     for (i = 0; i < WINDOWS; i++)
         window_present(&w.windows[i]);


### PR DESCRIPTION
There seems to be a compositor behaviour that affects the menus. It works for KWin, but Mutter seems to have issues. This is an attempt to harden the pointer-moving-between-surfaces-handling.