### PR TITLE
AES: wind_get refused to say which window was on top

### DIFF
--- a/src/aeswind.c
+++ b/src/aeswind.c
@@ -650,6 +650,32 @@ uint32_t AES_wind_get()
 
     desk_area();
 
+    /*
+     * The two that are about the screen rather than about a window, and are
+     * answered whatever handle they were asked with.
+     *
+     * Which window is on top and where the AES keeps its buffer are the same
+     * question wherever it is asked from, so the AES has never looked at the
+     * handle for either - see wm_get in EmuTOS's gemwmlib.c, where they are
+     * named as the fields that do not need a valid one. An application that
+     * has a number to hand and no reason to think about it passes whatever it
+     * has: GenST asks which window is on top and passes the handle of its
+     * workstation, and being refused it reads an intout nobody wrote, decides
+     * its window is not in front, and ignores everything picked from its menus.
+     */
+    switch (what)
+    {
+        case WF_SCREEN:
+            /* Where the AES keeps its own buffer, which it does not have one
+             * of here. Answering with nothing is how an application is told to
+             * do without it. */
+            answer_rect(0, 0, 0, 0);
+            return AES_E_OK;
+        case WF_TOP:
+            aes_set_intout(1, topped);
+            return AES_E_OK;
+    }
+
     /* The desktop is a window like any other as far as this is concerned, and
      * is what an application asks about to find out how large the screen is */
     if (handle == 0)
@@ -660,15 +686,6 @@ uint32_t AES_wind_get()
             case WF_CURRXYWH:
             case WF_FULLXYWH:
                 answer_rect(desk_x, desk_y, desk_w, desk_h);
-                return AES_E_OK;
-            case WF_SCREEN:
-                /* Where the AES keeps its own buffer, which it does not have
-                 * one of here. Answering with nothing is how an application is
-                 * told to do without it. */
-                answer_rect(0, 0, 0, 0);
-                return AES_E_OK;
-            case WF_TOP:
-                aes_set_intout(1, topped);
                 return AES_E_OK;
         }
     }
@@ -725,10 +742,6 @@ uint32_t AES_wind_get()
 
         case WF_NEXTXYWH:
             answer_rect(0, 0, 0, 0);
-            break;
-
-        case WF_TOP:
-            aes_set_intout(1, topped);
             break;
 
         case WF_HSLIDE:

--- a/tests/c-gem.c
+++ b/tests/c-gem.c
@@ -268,6 +268,34 @@ int main(int argc, char **argv)
         check(intout[1], 20, "wind_get gives back where it was put");
         check(intout[3], 200, "and how wide it was made");
 
+        /*
+         * Which window is on top. That is a question about the screen rather
+         * than about a window, and the AES has never looked at the handle it
+         * was asked with - see wm_get in EmuTOS's gemwmlib.c, where WF_TOP is
+         * named as one of the fields that needs no valid one.
+         *
+         * So it is asked here twice, the second time with a number that is not
+         * a window at all, because that is what applications do: one with a
+         * handle to hand and no reason to think about it passes whatever it
+         * has. GenST passes the handle of its workstation, and an AES that
+         * refuses leaves it reading an intout nobody wrote - it decides its
+         * window is not in front and ignores everything picked from its menus.
+         */
+        intin[0] = handle; intin[1] = 10;   /* WF_TOP */
+        intout[1] = -1;
+        check(call_aes(104, 6, 5, 0, 0), 1, "wind_get says which window is on top");
+        check(intout[1], handle, "and it is the one that was just opened");
+
+        intin[0] = handle + 1; intin[1] = 11;   /* WF_FIRSTXYWH */
+        check(call_aes(104, 6, 5, 0, 0), 0,
+              "a handle that is not a window is refused what a window has");
+
+        intin[0] = handle + 1; intin[1] = 10;   /* WF_TOP */
+        intout[1] = -1;
+        check(call_aes(104, 6, 5, 0, 0), 1,
+              "and answered anyway about which window is on top");
+        check(intout[1], handle, "with the one that is on top");
+
         /* The part to draw in is smaller, by the title bar */
         intin[0] = handle; intin[1] = 4;    /* WF_WORKXYWH */
         call_aes(104, 6, 5, 0, 0);


### PR DESCRIPTION
An application asks wind_get for WF_TOP to find out whether the window it is working in is the one in front. That is a question about the screen rather than about a window, and the AES has never looked at the handle it was asked with - wm_get in EmuTOS's gemwmlib.c names WF_TOP, WF_SCREEN and WF_DCOLOR as the fields that need no valid one, and answers them before it has decided whether the handle is a window at all.

tosemu looked the handle up first and answered nothing at all to anything that was not one of its own windows. An application that passes a number it has to hand - and there is no reason to pass a particular one, the answer being the same whoever asks - was told the call had failed, and read an intout nobody had written.

GenST is what showed it. It polls wind_get(2, WF_TOP) round its main loop, 2 being the handle of its workstation rather than of its window, decides from the rubbish it reads back that it is not in front, and then ignores everything picked from its menus: the menu drops down, the entry is chosen, MN_SELECTED arrives, and nothing happens - not even About. Nothing had noticed because everything written here asks about handle 0 or about a window it owns, and both of those were already answered.

WF_TOP and WF_SCREEN are now answered before the handle is looked up, whatever it was. That also closes a second hole in the same call: WF_SCREEN was only answered for handle 0, so an application asking it about a window of its own fell through to the default and stopped the emulator.