### PR TITLE
Add a console device window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,11 @@ runs through the whole program and most of the interesting bugs live on it.
       main.c cpu.c memory.c      the machine and its memory
       gemdos*.c bios.c xbios*.c  the OS calls, dispatched from traps
       aes*.c                     the AES: windows, menus, objects, events
+      console.c                  the text screen, and the keyboard it is read
+                                 from - a window or the terminal
       vdi.c                      the VDI trap, which hands arrays to emuvdi
-      emuvdi/                    EmuTOS's VDI and parts of its AES, hosted
+      emuvdi/                    EmuTOS's VDI, its console and parts of its
+                                 AES, hosted
       gfx.c surface.c            the screen as memory, and as windows
       printer.c                  a sheet of paper, and CUPS at the end of it
       screen.c                   which screen the machine has
@@ -139,6 +142,14 @@ misspelt name in a file get complained about instead of ignored.
 displays and a build server has none, so anything that asks Wayland has to be
 checked with `$(NO_DISPLAY)` for what it does when there is nothing to ask, and
 the arithmetic checked separately — that is what `bin/screentest` is for.
+
+The corollary has bitten: the whole suite runs with `TOSEMU_NO_WINDOW=1`, so
+every early return in `gfx.c` that begins `if (!gfx_showing())` is taken in
+every check. A change to which handles `gfx_window_open` will accept passed
+`make check` and stopped the menu bar getting a window, because with no window
+it never got one anyway. Anything touching that file wants running against a
+compositor by hand, and `WAYLAND_DEBUG=1 bin/tosemu prog.prg | grep set_title`
+is the cheap way to see which windows were really opened.
 
 ## Tests
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GEN   = $(BUILD)/gen
 BIN   = bin
 
 # Source files for TOS emulator, named as they are found under $(SRC)
-SOURCEFILES = main.c gemdos.c gemdosmem.c gemdoscon.c gemdosfile.c gemdosdrive.c gemdosproc.c \
+SOURCEFILES = main.c gemdos.c gemdosmem.c gemdoscon.c console.c gemdosfile.c gemdosdrive.c gemdosproc.c \
               xbios.c xbiosscreen.c xbiossys.c xbiosdev.c bios.c \
               gem.c aesclient.c aes.c aesappl.c aesevnt.c aesgraf.c aeswind.c aesmenu.c aesframe.c aesfsel.c aesobjc.c aesrsrc.c aesscrp.c aesshel.c aestree.c vdi.c surface.c \
               gfx.c screen.c settings.c scrap.c scraptext.c scrapimg.c \
@@ -45,6 +45,7 @@ EMUTOSFILES = $(EMUTOS)/vdi/vdi_main.c $(EMUTOS)/vdi/vdi_control.c \
               $(EMUTOS)/vdi/vdi_marker.c $(EMUTOS)/vdi/vdi_misc.c \
               $(EMUTOS)/vdi/vdi_text.c $(EMUTOS)/vdi/vdi_textblit.c \
               $(EMUTOS)/vdi/vdi_esc.c $(EMUTOS)/vdi/vdi_input.c \
+              $(EMUTOS)/bios/vt52.c \
               $(EMUTOS)/bios/fnt_st_6x6.c $(EMUTOS)/bios/fnt_st_8x8.c \
               $(EMUTOS)/bios/fnt_st_8x16.c \
               $(EMUTOS)/bios/fnt_off_6x6.c $(EMUTOS)/bios/fnt_off_8x8.c \
@@ -104,7 +105,7 @@ WAYLANDLIBS =
 WAYLANDONLYLIBS =
 endif
 
-EMUVDIFILES = emuvdi/hostvars.c emuvdi/hostfs.c emuvdi/fonts.c emuvdi/gdosfnt.c emuvdi/gdosfsm.c emuvdi/prndev.c emuvdi/textblit.c emuvdi/bridge.c \
+EMUVDIFILES = emuvdi/hostvars.c emuvdi/hostfs.c emuvdi/fonts.c emuvdi/gdosfnt.c emuvdi/gdosfsm.c emuvdi/prndev.c emuvdi/textblit.c emuvdi/conout.c emuvdi/bridge.c \
               emuvdi/gsx2.c emuvdi/gemoblib.c emuvdi/gemobjop.c emuvdi/gemfmalt.c emuvdi/gemmnlib.c emuvdi/vdi_raster.c emuvdi/aeskernel.c \
               emuvdi/strings.c
 

--- a/README.md
+++ b/README.md
@@ -437,6 +437,34 @@ A program waiting for a key with no way for one to arrive is stopped and told
 so, rather than left waiting: no window and no keyboard, or standard input that
 has ended. That is the same answer `evnt_multi` gives for the same dead end.
 
+Copy and paste
+--------------
+
+The text in a console window can be selected and copied, which is the one thing
+a terminal does that the screen console would otherwise not.
+
+Drag across it with the left button and the cells turn inside out to show what
+is selected; letting go puts the text on the desktop's clipboard. A click that
+went nowhere selects nothing rather than copying the character under it, and the
+right button takes a selection away. The middle button pastes, the way it does
+in a terminal: what the desktop is offering arrives as keys, so a program gets
+it through whatever it is already using to read the keyboard.
+
+Letting go is what copies, rather than a key combination, because every key
+belongs to the program - it is sitting in a console read waiting for one, and
+any this took would be one it never saw. A terminal can afford Ctrl-Shift-C
+because the shell underneath it is not listening for Ctrl-Shift-C.
+
+What is copied is the characters, not the pixels. A cell holding an A is eight
+by sixteen bits that happen to look like one, so the characters are kept beside
+them as they are drawn - which is also why the text a line was padded out with
+does not come along, and why a selection three lines tall is three lines rather
+than a hundred and fifty spaces.
+
+None of it is a GEM cut. No application made the selection and none knows it
+happened, so nothing is written to the scrap directory and no other GEM program
+can paste it; it goes straight to the desktop, where a person put it.
+
 
 Fonts
 =====

--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ be there rather than one that has to be.
     keys   = \r
     clicks = 100,50 200,60
 
+    [console]
+    output = screen
+
     [files]
     base = /home/me/tos
 
@@ -292,6 +295,7 @@ Which is which:
 | `[machine] memory`     | `TOSEMU_MEMORY`      |
 | `[input] keys`         | `TOSEMU_KEYS`        |
 | `[input] clicks`       | `TOSEMU_CLICKS`      |
+| `[console] output`     | `TOSEMU_CONSOLE`     |
 | `[files] base`         | `TOS_BASE_PATH`      |
 | `[fonts] assign`       | `TOSEMU_FONTS_ASSIGN` |
 | `[fonts] substitutes`  | `TOSEMU_FONTS_SUBSTITUTES` |
@@ -393,6 +397,45 @@ compiler drivers use the ARGV convention: a length byte of 127 says the
 arguments were passed through an `ARGV` variable in the environment instead,
 which tosemu carries from one program to the next as it stands.
 
+
+
+The console
+===========
+
+An ST's console was its own screen and keyboard, reached through the VT52 in the
+BIOS, and it was the same screen GEM drew on. Programs that were both are the
+rule rather than the exception for software of the period: an assembler with a
+GEM editor round it writes its listing over the desktop, waits for a key and
+leaves the application to redraw.
+
+There are two places it can go here and the difference is not a preference.
+
+On the screen, which is what a GEM program gets: a window of its own, the text
+drawn with the machine's own 8x16 font, the Atari character set, and the VT52
+escape sequences meaning what they meant. It is the faithful answer and it is
+where the person is already looking. The window appears when a character
+actually reaches it - a program that only sets the wrap mode has said nothing -
+and goes when the application next waits for a GEM event, which is where an ST
+redrew over the text.
+
+On the terminal tosemu was started from, which is what a program run from a
+shell gets. That is where console output has always gone, it is what a Makefile
+reads and what a redirect captures, and the bytes are passed through as they
+were written. The terminal goes into cbreak while the program is running so that
+a keypress is a keypress rather than a line, and is put back at the end.
+
+Which one it is comes from whether GEM has been started - by this program or by
+the one that ran it, so GenST's assembler counts as a GEM program even though it
+never calls GEM itself - and from whether there is a compositor to put a window
+on. `TOSEMU_CONSOLE` says it outright: `screen` asks for a console screen even
+with no desktop to show it on, where it is drawn and can be looked at with
+`TOSEMU_SCREENSHOT`, and `terminal` asks for the terminal on a machine that has
+one, which is what somebody redirecting an assembler's listing into a file
+wants.
+
+A program waiting for a key with no way for one to arrive is stopped and told
+so, rather than left waiting: no window and no keyboard, or standard input that
+has ended. That is the same answer `evnt_multi` gives for the same dead end.
 
 
 Fonts

--- a/TODO
+++ b/TODO
@@ -33,8 +33,10 @@
   everywhere a handle is taken. Lattice's startup code calls Fforce(4, -2).
   tosemu has a console but no serial port or printer, so -1 is the one with an
   answer to give, and the other two keep reporting EIHNDL.
-- Console output goes straight to the host rather than through handle 1, so
-  Cconout and Cconws ignore an Fforce that redirected it.
+- Console output goes to the console rather than through handle 1, so Cconout
+  and Cconws ignore an Fforce that redirected it. Everything a program writes
+  now passes through one place - console.c - which is what makes this doable at
+  all; before it there was no single point to redirect.
 - Ptermres, which has nowhere to stay resident in.
 - remove_memory_area never advances its pointer, so it only ever finds the
   first area. reset_memory happens to always ask for that one.
@@ -379,3 +381,31 @@
   printer it is pretending to be and rendering that, or handing the bytes to
   CUPS as text and letting the queue make what it can of them. The second is
   cheap and is probably what a program that does this wants.
+
+- The console on a terminal passes the VT52 through rather than interpreting
+  it. A program that clears the screen sends ESC E and the terminal, which
+  speaks ANSI, prints an E; GenST sets the wrap mode with ESC v and a stray v
+  is what starts its output. The Atari character set goes out raw as well, so
+  an accented letter is a byte no UTF-8 terminal has a glyph for.
+
+  Neither is worth fixing there, which is why this is written down rather than
+  done: the console on a screen has the VT52 and the Atari font and gets both
+  right, and the terminal one exists so that a program's output can be piped
+  into a file or read by a Makefile - which is a use that wants the bytes as
+  they were written. What would close it is translating the escapes a terminal
+  can express and dropping the rest, the way EmuTOS's CONF_SERIAL_CONSOLE_ANSI
+  does, and it would cost the pipe its transparency.
+
+- A console window is taken away when the application next waits for a GEM
+  event, which is where an ST redrew over the text. A program that writes a
+  line, goes round its event loop and writes another therefore gets a window
+  that flashes. Nothing seen here does it - a program that drops to the console
+  stays there until it is finished - and the alternative is a rule about how
+  long a console stays up, which is the same kind of guess the drawing
+  heuristics above are.
+
+- The console reads standard input and so does Fread on handle 0, and neither
+  knows about the other. Asking whether a key is waiting reads one and keeps
+  it, so a program that mixes the two can have a byte taken by the console that
+  it meant to read as a file. It is the same seam as the handle 1 item above
+  and closes with it.

--- a/TODO
+++ b/TODO
@@ -409,3 +409,19 @@
   it, so a program that mixes the two can have a byte taken by the console that
   it meant to read as a file. It is the same seam as the handle 1 item above
   and closes with it.
+
+- Nothing in make check reaches the pointer half of selecting text on the
+  console: the drag that makes a selection, the release that copies it and the
+  middle button that pastes. The suite runs with no window, so there is no
+  console window for a pointer to be in, and injected input goes to the queue
+  the AES reads rather than to the console - which is right, a console window
+  being a window GEM knows nothing about.
+
+  What is checked is everything underneath, in bin/vditest: the copy of the
+  characters conout.c keeps beside the pixels, that it scrolls when they do,
+  what comes back for a range and for one named backwards, and the blanks a
+  line was padded out with being dropped. What is not is the forty lines that
+  turn a place the pointer was into two cells, and those have not been watched
+  working either - unlike the window frame's gadgets, which are in the same
+  position and were at least driven by hand against kwin. This wants somebody
+  dragging across a console window and pasting into one before it is believed.

--- a/src/aesevnt.c
+++ b/src/aesevnt.c
@@ -46,6 +46,7 @@
 #include <string.h>
 #include <time.h>
 
+#include "console.h"
 #include "gem_p.h"
 #include "aesclient.h"
 #include "gfx.h"
@@ -196,6 +197,17 @@ static int16_t wait_for(int16_t wanted, long timeout, int16_t *message,
      * picture is finished as far as anyone watching is concerned.
      */
     gem_present();
+
+    /*
+     * And whatever console the application dropped to goes now.
+     *
+     * Waiting for a GEM event is what says it has finished with the console
+     * and gone back to being a GEM program - the two do not happen at once,
+     * because a program reading the console is inside that read. On an ST this
+     * is where its own redraw covered the console text over; here the text has
+     * a window of its own, and what happens instead is that the window goes.
+     */
+    console_settle();
 
     /*
      * The state that answered the last question is stale once something else

--- a/src/bios.c
+++ b/src/bios.c
@@ -26,6 +26,7 @@
 #include <stdint.h>
 
 #include "tossystem.h"
+#include "console.h"
 #include "cpu.h"
 #include "m68k.h"
 #include "utils.h"
@@ -90,8 +91,10 @@ uint32_t BIOS_Bconin()
         printf("    dev: 0x%x\n", dev);
     }
 
-    if (is_console(dev) && console_input_available())
-        return getchar() & 0xff;
+    /* Waits, the way the console's own read does and for the same reason: a
+     * program asking the keyboard for a key has stopped until it gets one */
+    if (is_console(dev))
+        return console_key(1);
 
     /* Nothing arrives from a device that is not there */
     return 0;
@@ -107,7 +110,7 @@ uint32_t BIOS_Bconout()
     }
 
     if (is_console(dev))
-        putchar(c);
+        console_out(c);
 
     /* Bytes for the printer, the serial port, MIDI and the keyboard
      * controller have nowhere to go */
@@ -123,7 +126,7 @@ uint32_t BIOS_Bconstat()
         printf("    dev: 0x%x\n", dev);
     }
 
-    if (is_console(dev) && console_input_available())
+    if (is_console(dev) && console_ready())
         return -1;
 
     return 0;

--- a/src/console.c
+++ b/src/console.c
@@ -51,6 +51,8 @@
 #include "config.h"
 #include "gem_p.h"
 #include "gfx.h"
+#include "scrap.h"
+#include "scraptext.h"
 #include "settings.h"
 #include "surface.h"
 #include "tossystem.h"
@@ -90,7 +92,40 @@ static struct {
     int have;                   /* one key read ahead - see terminal_fill */
     unsigned char ahead;
     struct termios was;
+
+    /* Keys still to come out of something pasted into the console window */
+    char *pasted;
+    int pasted_length;
+    int pasted_at;
 } c;
+
+/*
+ * What has been selected in the console window, to be copied out of it.
+ *
+ * A console window is not a GEM window and the application knows nothing about
+ * it, so the pointer in it is not the application's business either - which
+ * leaves it free to mean what it means in a terminal. Dragging selects, letting
+ * go copies, and the middle button pastes.
+ *
+ * Letting go is what copies, rather than a key, because every key belongs to
+ * the program: it is sitting in a console read waiting for one, and any that
+ * this took would be one it never saw. A terminal can afford Ctrl-Shift-C
+ * because the shell underneath it is not listening for Ctrl-Shift-C.
+ *
+ * The selection is shown by turning the cells inside out, which is how the
+ * cursor is shown and for the same reason: doing it twice puts back what was
+ * there, so nothing has to be remembered.
+ */
+static struct {
+    int16_t px, py;             /* where the pointer was, in console pixels */
+
+    int dragging;
+    int moved;                  /* and it has been somewhere else since */
+    int shown;                  /* the cells are currently inside out */
+
+    int16_t ax, ay;             /* where the drag started, in cells */
+    int16_t bx, by;             /* and where it has reached */
+} sel;
 
 /* Milliseconds since some fixed point, which is all staleness needs */
 static long now_ms(void)
@@ -332,16 +367,349 @@ static void screen_show(int wanted)
     c.stale = 0;
 }
 
-static void screen_out(int ch)
+/*
+ * The same, for something that changed what is on the console without the
+ * program having written anything.
+ *
+ * A selection appearing and disappearing as the pointer moves is the one thing
+ * here that has to be on the screen at once rather than when the next character
+ * comes out - there may not be a next character, the program being sat in a
+ * read - and it is not worth a screenshot, nobody having asked for a picture of
+ * a half finished drag.
+ */
+static void screen_present(void)
 {
-    /* Borrowed and given back, the way a printer workstation borrows it - see
-     * emuvdi/prndev.c. Everything the VDI draws goes to whatever was selected
-     * last, and the application is entitled to go on drawing where it was */
+    if (c.windowed)
+        gfx_present();
+}
+
+/* Selecting, copying and pasting *******************************************/
+
+/*
+ * Borrowing the console's surface for a moment.
+ *
+ * Everything the VDI draws goes to whatever was selected last, so anything that
+ * touches the console has to say so and put back what it found - the way a
+ * printer workstation does, see emuvdi/prndev.c. The application is entitled to
+ * go on drawing where it was.
+ */
+static struct surface *console_borrow(void)
+{
     struct surface *was = surface_selected();
 
     surface_select(c.shows);
-    emuvdi_console_out(ch);
+
+    return was;
+}
+
+static void console_return(struct surface *was)
+{
     surface_select(was ? was : gem_screen_surface());
+}
+
+/* What is on the console now, so that a place the pointer was can be turned
+ * into a place in the text */
+static void console_cells(int16_t *cols, int16_t *rows,
+                          int16_t *width, int16_t *height)
+{
+    struct surface *was = console_borrow();
+
+    emuvdi_console_cells(cols, rows, width, height);
+
+    console_return(was);
+}
+
+/*
+ * The selected cells, turned inside out or put back.
+ *
+ * The same operation both ways round, which is what makes it safe: there is no
+ * copy of what was underneath to get out of step with what is drawn. What it
+ * does mean is that nothing may draw over those cells while they are inverted,
+ * which is why writing to the console takes the selection away first.
+ */
+static void selection_paint(void)
+{
+    struct surface *was;
+    int16_t cols, rows, cw, ch;
+    int16_t ax = sel.ax, ay = sel.ay, bx = sel.bx, by = sel.by;
+    int16_t y;
+
+    if (!c.shows)
+        return;
+
+    was = console_borrow();
+
+    emuvdi_console_cells(&cols, &rows, &cw, &ch);
+
+    /* Reading order, whichever end the drag started at */
+    if (ay > by || (ay == by && ax > bx))
+    {
+        int16_t t;
+
+        t = ax; ax = bx; bx = t;
+        t = ay; ay = by; by = t;
+    }
+
+    for (y = ay; y <= by && y < rows; y++)
+    {
+        int16_t from = (y == ay) ? ax : 0;
+        int16_t to = (y == by) ? bx : (int16_t)(cols - 1);
+        int16_t x;
+
+        for (x = from; x <= to && x < cols; x++)
+            emuvdi_console_invert(x, y);
+    }
+
+    console_return(was);
+}
+
+static void screen_present(void);
+
+/* Taking the selection away, which is what anything that changes the console
+ * has to do before it changes it */
+static void selection_clear(void)
+{
+    if (!sel.shown)
+        return;
+
+    selection_paint();
+    sel.shown = 0;
+
+    screen_present();
+}
+
+/*
+ * What was selected, on the desktop's clipboard.
+ *
+ * Straight to the desktop rather than through the scrap directory: this is not
+ * a GEM cut - no application made it and none knows it happened - so there is
+ * no SCRAP file for one to have written and nothing for another GEM program to
+ * find. What a person selected in a console window is for the desktop.
+ */
+static void selection_copy(void)
+{
+    struct surface *was;
+    char atari[4096];
+    char *utf8;
+    size_t utf8_length;
+    int length;
+
+    if (!c.shows)
+        return;
+
+    was = console_borrow();
+    length = emuvdi_console_text(sel.ax, sel.ay, sel.bx, sel.by,
+                                 atari, (int)sizeof atari);
+    console_return(was);
+
+    if (length <= 0)
+        return;
+
+    utf8 = scrap_text_to_utf8(atari, (size_t)length, &utf8_length);
+    if (!utf8)
+        return;
+
+    scrap_desktop_give_text(utf8, utf8_length);
+
+    free(utf8);
+}
+
+/*
+ * And the other way: what the desktop is offering, as keys.
+ *
+ * Keys rather than characters, because a console read is a read of the
+ * keyboard - so a paste has to arrive the way typing does, one key at a time
+ * through whatever the program is using to ask for them. Which also means a
+ * program that is not reading the keyboard gets nothing until it does, exactly
+ * as it would if somebody typed while it was busy.
+ */
+static void selection_paste(void)
+{
+    char *utf8;
+    char *text;
+    size_t utf8_length, length;
+
+    utf8 = scrap_desktop_text(&utf8_length);
+    if (!utf8)
+        return;
+
+    text = scrap_text_from_utf8(utf8, utf8_length, &length);
+    free(utf8);
+
+    if (!text)
+        return;
+
+    if (length == 0)
+    {
+        free(text);
+        return;
+    }
+
+    free(c.pasted);
+
+    c.pasted = text;
+    c.pasted_length = (int)length;
+    c.pasted_at = 0;
+}
+
+/* A key out of what was pasted, or 0 when there is none left */
+static uint32_t pasted_key(void)
+{
+    unsigned char ch;
+
+    while (c.pasted && c.pasted_at < c.pasted_length)
+    {
+        ch = (unsigned char)c.pasted[c.pasted_at++];
+
+        /*
+         * A line ending is one key. An ST spells it CR LF, which is what
+         * scraptext hands back, and what a person pressing Return produces is
+         * the CR - so the LF after it is dropped rather than delivered as a
+         * character nobody typed.
+         */
+        if (ch == '\n')
+            continue;
+
+        /* Return carries the scan code a program looking for it expects; the
+         * rest are characters, which is all a clipboard has */
+        if (ch == '\r')
+            return (0x1cu << 16) | '\r';
+
+        return ch;
+    }
+
+    free(c.pasted);
+    c.pasted = 0;
+    c.pasted_length = 0;
+    c.pasted_at = 0;
+
+    return 0;
+}
+
+void host_console_motion(int16_t x, int16_t y)
+{
+    sel.px = x;
+    sel.py = y;
+
+    if (!sel.dragging)
+        return;
+
+    {
+        int16_t cols, rows, cw, ch;
+        int16_t cx, cy;
+
+        console_cells(&cols, &rows, &cw, &ch);
+
+        if (cw <= 0 || ch <= 0)
+            return;
+
+        cx = (int16_t)(x / cw);
+        cy = (int16_t)(y / ch);
+
+        if (cx < 0) cx = 0;
+        if (cy < 0) cy = 0;
+        if (cx >= cols) cx = (int16_t)(cols - 1);
+        if (cy >= rows) cy = (int16_t)(rows - 1);
+
+        if (cx == sel.bx && cy == sel.by)
+            return;
+
+        /* Off and on again rather than worked out as a difference: the shape
+         * of a selection changes wholesale when the drag crosses a line */
+        if (sel.shown)
+            selection_paint();
+
+        sel.bx = cx;
+        sel.by = cy;
+        sel.moved = 1;
+
+        selection_paint();
+        sel.shown = 1;
+
+        screen_present();
+    }
+}
+
+void host_console_button(int16_t button, int down)
+{
+    int16_t cols, rows, cw, ch;
+
+    if (!c.shows)
+        return;
+
+    /* The middle one pastes, the way it does in a terminal, and does it on the
+     * press because that is when the person did it */
+    if (button == 3)
+    {
+        if (down)
+            selection_paste();
+
+        return;
+    }
+
+    /* And the right one takes a selection away, there being nothing else for
+     * it to mean here */
+    if (button == 2)
+    {
+        if (down)
+            selection_clear();
+
+        return;
+    }
+
+    console_cells(&cols, &rows, &cw, &ch);
+
+    if (cw <= 0 || ch <= 0)
+        return;
+
+    if (down)
+    {
+        selection_clear();
+
+        sel.ax = sel.bx = (int16_t)(sel.px / cw);
+        sel.ay = sel.by = (int16_t)(sel.py / ch);
+
+        if (sel.ax >= cols) sel.ax = sel.bx = (int16_t)(cols - 1);
+        if (sel.ay >= rows) sel.ay = sel.by = (int16_t)(rows - 1);
+
+        sel.dragging = 1;
+        sel.moved = 0;
+
+        return;
+    }
+
+    sel.dragging = 0;
+
+    /*
+     * A press that never went anywhere is a click rather than a selection, and
+     * a click means "nothing is selected" - copying the one character under the
+     * pointer would put something on the clipboard that nobody asked for.
+     */
+    if (!sel.moved)
+    {
+        selection_clear();
+        return;
+    }
+
+    selection_copy();
+}
+
+/* What a console is for, still ***********************************************/
+
+static void screen_out(int ch)
+{
+    struct surface *was;
+
+    /*
+     * Whatever was selected stops being selected the moment something is
+     * written, because the selection is shown by turning cells inside out and
+     * a cell drawn over while it is inverted can never be put back.
+     */
+    selection_clear();
+
+    was = console_borrow();
+    emuvdi_console_out(ch);
+    console_return(was);
 
     c.stale = 1;
 
@@ -473,8 +841,15 @@ static uint32_t screen_key(int wait)
     for (;;)
     {
         uint16_t key;
+        uint32_t from_paste;
         struct pollfd waiting;
         int fd;
+
+        /* What was pasted comes first and comes before anything typed, being
+         * already in hand */
+        from_paste = pasted_key();
+        if (from_paste)
+            return from_paste;
 
         /* What is on the console before a key is asked for, so that a prompt
          * is on the screen before anybody is expected to answer it */
@@ -571,6 +946,10 @@ int console_ready(void)
         screen_show(0);
 
     gfx_dispatch_ready();
+
+    /* Something pasted is a key waiting as much as one being held down is */
+    if (c.pasted && c.pasted_at < c.pasted_length)
+        return 1;
 
     return gfx_key_ready();
 }
@@ -690,6 +1069,11 @@ void console_settle(void)
      * goes back to the console carries on where it left off - which is what an
      * ST did, the text being on a screen nobody had erased.
      */
+    /* The selection with it. It is shown by turning cells inside out, and one
+     * left that way would be waiting to be found the next time the console
+     * comes back - inverted, and with nothing left that knows why. */
+    selection_clear();
+
     if (c.windowed)
         gfx_console_close();
 
@@ -720,6 +1104,13 @@ void console_forget(void)
     c.decided = 0;
     c.on_screen = 0;
 
+    free(c.pasted);
+    c.pasted = 0;
+    c.pasted_length = 0;
+    c.pasted_at = 0;
+
+    memset(&sel, 0, sizeof sel);
+
     /*
      * The terminal is not forgotten with the rest. It belongs to the process
      * rather than to the program, and this process shares it with the one that
@@ -738,5 +1129,8 @@ void console_close(void)
     if (c.shows)
         surface_free(c.shows);
 
+    free(c.pasted);
+
     memset(&c, 0, sizeof c);
+    memset(&sel, 0, sizeof sel);
 }

--- a/src/console.c
+++ b/src/console.c
@@ -1,0 +1,742 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * The console, on a screen or on a terminal.
+ *
+ * See console.h for what it is for. This file is the two back ends and the
+ * decision between them, and nothing above it knows which one is running.
+ *
+ * The screen one is EmuTOS's VT52 - bios/vt52.c, compiled out of the submodule
+ * - drawing through emuvdi/conout.c into a surface of the console's own. It is
+ * a surface rather than the screen itself for the same reason a dialog's is:
+ * what the console draws would otherwise appear inside every window showing
+ * that part of the screen. See gem_dialog_begin.
+ *
+ * The terminal one is stdout and stdin. The only thing it has to do carefully
+ * is the tty: a program waiting for a keypress wants the key when it is
+ * pressed, and a terminal in its usual state hands nothing over until the line
+ * is finished. So the first time anything reads the console it goes into
+ * cbreak, and it is put back at the end of the run.
+ */
+
+#include "console.h"
+
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <termios.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "config.h"
+#include "gem_p.h"
+#include "gfx.h"
+#include "settings.h"
+#include "surface.h"
+#include "tossystem.h"
+#include "emuvdi/emuvdi.h"
+
+/*
+ * How long the console may go without being put on the screen.
+ *
+ * Drawing a character is cheap and showing a window is not - every pixel of it
+ * is turned into a colour and handed to the compositor - so a page of output
+ * shown a character at a time would be a thousand of those. This is how stale
+ * what can be seen is allowed to get, and it is short enough that output looks
+ * continuous and long enough that a page costs a handful of them rather than
+ * one each.
+ *
+ * Anything that waits shows what is there first, whatever this says, so a
+ * program that writes a prompt and waits never shows the prompt late.
+ */
+#define STALE_MS (20)
+
+static struct {
+    /* Which of the two this is, once it has been decided */
+    int decided;
+    int on_screen;
+
+    /* The screen console */
+    struct surface *shows;
+    int up;                     /* and there is something on it to look at */
+    int windowed;               /* and a window of the desktop's showing it */
+    unsigned long seen;         /* characters drawn when it last went away */
+    long shown_at;              /* when the window last caught up */
+    int stale;
+
+    /* The terminal console */
+    int raw;                    /* the tty has been put into cbreak */
+    int ended;                  /* and has nothing more to give */
+    int have;                   /* one key read ahead - see terminal_fill */
+    unsigned char ahead;
+    struct termios was;
+} c;
+
+/* Milliseconds since some fixed point, which is all staleness needs */
+static long now_ms(void)
+{
+    struct timespec t;
+
+    clock_gettime(CLOCK_MONOTONIC, &t);
+
+    return (long)t.tv_sec * 1000 + t.tv_nsec / 1000000;
+}
+
+/* The terminal *************************************************************/
+
+static void terminal_restore(void)
+{
+    if (!c.raw)
+        return;
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &c.was);
+    c.raw = 0;
+}
+
+/*
+ * The terminal, arranged so that a key can be read as a key.
+ *
+ * A tty in its usual state collects a line and hands it over when Return is
+ * pressed, which is line editing done by the kernel on the shell's behalf. A
+ * program asking for one keypress wants none of that: it wants the key, and
+ * asking whether one is waiting has to be able to answer yes before the line
+ * is finished. So ICANON goes, and with it ECHO, because what is echoed is
+ * this console's business - Cconin shows what was typed and Cnecin does not.
+ *
+ * ISIG stays, so Ctrl-C still stops the emulator. That matters more here than
+ * anywhere else: a program polling the console for a key is the one place a
+ * person is most likely to want out.
+ *
+ * Done once and undone at the end rather than around each read. A poll is a
+ * poll because it happens millions of times - see the note in gemdoscon.c
+ * about Crawio - and two tcsetattr calls apiece is not a price to pay for it.
+ */
+static void terminal_raw(void)
+{
+    struct termios now;
+
+    if (c.raw)
+        return;
+
+    if (tcgetattr(STDIN_FILENO, &c.was) != 0)
+        return;         /* not a terminal, so there is nothing to arrange */
+
+    now = c.was;
+    now.c_lflag &= ~(ICANON | ECHO);
+    now.c_cc[VMIN] = 1;
+    now.c_cc[VTIME] = 0;
+
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &now) != 0)
+        return;
+
+    c.raw = 1;
+}
+
+/*
+ * Whether there is a key, and one read ahead if there is.
+ *
+ * Reading ahead is what tells a key from the end of the input. A pipe or a
+ * file that has run out is always ready to be read and always reads nothing,
+ * so asking whether something is there answers yes for ever and reading it
+ * hands over nothing for ever - which is how a wait for a keypress turned into
+ * a run that never ended, and how the end of a file turned into a character
+ * nobody typed. The only way to know which it is is to take it.
+ *
+ * The end is then remembered rather than found out again, because a program
+ * polling for a key polls millions of times and every one of them would be a
+ * read that answers the same thing.
+ */
+static int terminal_fill(void)
+{
+    struct pollfd waiting;
+    unsigned char ch;
+    ssize_t n;
+
+    if (c.have)
+        return 1;
+
+    if (c.ended)
+        return 0;
+
+    terminal_raw();
+
+    waiting.fd = STDIN_FILENO;
+    waiting.events = POLLIN;
+    waiting.revents = 0;
+
+    if (poll(&waiting, 1, 0) <= 0)
+        return 0;
+
+    n = read(STDIN_FILENO, &ch, 1);
+
+    if (n == 1)
+    {
+        c.have = 1;
+        c.ahead = ch;
+        return 1;
+    }
+
+    /* A signal arriving in the middle of a read is not the end of the input,
+     * so leave it to whoever asks next */
+    if (n < 0 && errno == EINTR)
+        return 0;
+
+    c.ended = 1;
+
+    return 0;
+}
+
+static int terminal_ready(void)
+{
+    return terminal_fill();
+}
+
+/* One byte from the terminal, or -1 when there is nothing and none was to be
+ * waited for */
+static int terminal_byte(int wait)
+{
+    for (;;)
+    {
+        struct pollfd waiting;
+
+        if (terminal_fill())
+        {
+            c.have = 0;
+            return c.ahead;
+        }
+
+        if (!wait || c.ended)
+            return -1;
+
+        waiting.fd = STDIN_FILENO;
+        waiting.events = POLLIN;
+        waiting.revents = 0;
+
+        poll(&waiting, 1, -1);
+    }
+}
+
+/* The screen ***************************************************************/
+
+/*
+ * Somewhere to draw and, if there is a compositor, somewhere to show it.
+ *
+ * The surface is the size of the screen, so the console is as many characters
+ * across as an ST's was on the same screen - eighty by twenty five in the high
+ * resolution GEM was written for. It is not the screen itself: see the note at
+ * the top of the file.
+ */
+static int screen_start(void)
+{
+    struct surface *screen;
+
+    if (c.shows)
+        return 1;
+
+    if (!gem_start())
+        return 0;
+
+    screen = gem_screen_surface();
+    if (!screen)
+        return 0;
+
+    c.shows = surface_create(surface_width(screen), surface_height(screen),
+                             surface_planes(screen));
+    if (!c.shows)
+        return 0;
+
+    /* The VT52 readies itself against whatever is selected, which is where it
+     * takes the shape of the grid from */
+    surface_select(c.shows);
+    emuvdi_console_init();
+    surface_select(screen);
+
+    return 1;
+}
+
+/*
+ * Everything the console has drawn, on the desktop.
+ *
+ * The window is opened here rather than when the console was written to,
+ * because a program that writes an escape sequence and nothing else has not
+ * said anything: GenST sets the wrap mode at startup and goes on being an
+ * editor. So the window waits until a character has actually appeared, which
+ * is what emuvdi_console_written counts, or until something asks for a key -
+ * because a person cannot press one at a window that is not there.
+ *
+ * Counted since the console last went away rather than since the run started,
+ * so a program that comes back to GEM and then writes another escape sequence
+ * does not get the window back for it.
+ */
+static void screen_show(int wanted)
+{
+    if (!c.shows)
+        return;
+
+    if (!c.up)
+    {
+        if (!wanted && emuvdi_console_written() == c.seen)
+            return;
+
+        c.up = 1;
+    }
+
+    /* A window for it when there is a desktop to put one on. Without one the
+     * console is still up, still drawn and still read from - it is only
+     * unseen, which is the same arrangement the screen itself has */
+    if (gfx_showing() && !c.windowed)
+    {
+        gfx_console_open(c.shows, surface_width(c.shows),
+                         surface_height(c.shows));
+        c.windowed = 1;
+    }
+
+    gfx_present();
+
+    /*
+     * And into a file, for whoever is watching without a desktop.
+     *
+     * gem_present does the same for the screen and would do it for the console
+     * as well, but only when the application stops to wait for GEM - and a
+     * program that has dropped to the console is not waiting for GEM, so for
+     * the case this is most wanted in it would never happen.
+     */
+    {
+        const char *shot = setting("TOSEMU_SCREENSHOT");
+
+        if (shot)
+            surface_write_ppm(c.shows, shot);
+    }
+
+    c.shown_at = now_ms();
+    c.stale = 0;
+}
+
+static void screen_out(int ch)
+{
+    /* Borrowed and given back, the way a printer workstation borrows it - see
+     * emuvdi/prndev.c. Everything the VDI draws goes to whatever was selected
+     * last, and the application is entitled to go on drawing where it was */
+    struct surface *was = surface_selected();
+
+    surface_select(c.shows);
+    emuvdi_console_out(ch);
+    surface_select(was ? was : gem_screen_surface());
+
+    c.stale = 1;
+
+    /* Caught up with often enough to look continuous, rather than once a
+     * character - see STALE_MS */
+    if (now_ms() - c.shown_at >= STALE_MS)
+        screen_show(0);
+}
+
+/* Which console this is *****************************************************/
+
+/*
+ * On the screen for a GEM program, and on the terminal for one a person ran
+ * from a shell.
+ *
+ * Two questions, and both have to be yes. There has to be a desktop to put a
+ * console window on, which rules out a test, a build server and a machine with
+ * nobody logged in. And the program has to be one that came out of GEM, which
+ * is what gem_ever_started answers: a GEM application that drops to the
+ * console has taken the screen over and the person is looking at the screen,
+ * where a .TTP somebody typed the name of is talking to the shell they typed
+ * it in and should go on doing so.
+ *
+ * That second half is what makes the two cases this has to serve both work.
+ * GenST assembles by running its assembler as a child, and the child never
+ * calls GEM in its life - but it was started by an editor that has the screen,
+ * so its output belongs there. The same assembler run from a shell as GEN.TTP
+ * belongs in the shell, and its output is something a Makefile reads.
+ *
+ * It is decided once and stands for the run, because a program whose output
+ * moved halfway through would be worse than either. TOSEMU_CONSOLE says it
+ * outright: a screen console can be asked for on a machine with no compositor,
+ * where it is drawn and seen only in a screenshot, and the terminal can be
+ * asked for by somebody redirecting a GEM assembler's listing into a file.
+ */
+static int console_wanted_on_screen(void);
+
+/*
+ * The end of the run, however it comes.
+ *
+ * An application finishes by calling Pterm, which is exit and not a return
+ * from anything - so there is no place in the emulator where a program is
+ * known to have stopped, and this is registered rather than called. Two things
+ * have to happen there: the last moment's worth of output goes on the screen,
+ * which is what STALE_MS leaves outstanding, and the terminal goes back to how
+ * it was found.
+ */
+static void console_finish(void)
+{
+    if (c.stale)
+        screen_show(0);
+
+    terminal_restore();
+}
+
+static int console_wanted_on_screen(void)
+{
+    const char *want = setting("TOSEMU_CONSOLE");
+
+    if (!want)
+        return gfx_possible() && gem_ever_started();
+
+    if (strcmp(want, "screen") == 0)
+        return 1;
+
+    if (strcmp(want, "terminal") == 0)
+        return 0;
+
+    printf("tosemu: console = %s, which is neither screen nor terminal, "
+           "so the terminal it is\n", want);
+
+    return 0;
+}
+
+static void decide(void)
+{
+    /*
+     * Outside the state below, because a child of fork inherits both and only
+     * one of them is forgotten. What atexit was told stays told across a fork,
+     * so saying it twice would run the ending twice.
+     */
+    static int registered;
+
+    if (c.decided)
+        return;
+
+    c.decided = 1;
+
+    if (!registered)
+    {
+        registered = 1;
+        atexit(console_finish);
+    }
+
+    c.on_screen = console_wanted_on_screen();
+
+    /* Asking for a screen console and finding no room for one is worth saying,
+     * because what happens instead is that the output appears somewhere the
+     * person was not looking */
+    if (c.on_screen && !screen_start())
+    {
+        printf("Console: there was no room for a console screen, so the "
+               "terminal it is\n");
+        c.on_screen = 0;
+    }
+}
+
+/* What a console is for ****************************************************/
+
+void console_out(int ch)
+{
+    decide();
+
+    if (c.on_screen)
+        screen_out(ch & 0xff);
+    else
+        putchar(ch & 0xff);
+}
+
+/*
+ * A key from whichever console this is.
+ *
+ * The screen one reads the window's keyboard, which is the same queue the AES
+ * takes its keys off - a console window is a window, and a key pressed in it
+ * arrives the way any other does. The terminal one reads stdin.
+ */
+static uint32_t screen_key(int wait)
+{
+    for (;;)
+    {
+        uint16_t key;
+        struct pollfd waiting;
+        int fd;
+
+        /* What is on the console before a key is asked for, so that a prompt
+         * is on the screen before anybody is expected to answer it */
+        if (c.stale || (wait && !c.up))
+            screen_show(wait);
+
+        gfx_dispatch_ready();
+
+        if (gfx_key_take(&key))
+            return ((uint32_t)(key >> 8) << 16) | (key & 0xff);
+
+        if (!wait)
+            return 0;
+
+        fd = gfx_fd();
+
+        /*
+         * Waiting for a key with nothing that could ever deliver one.
+         *
+         * The same dead end evnt_multi reaches when an application waits for
+         * the keyboard with no window for one to arrive at, and it ends the
+         * same way. A console read does not return until it has a key, so
+         * there is no answer to give and nothing further to try.
+         */
+        if (fd < 0)
+        {
+            printf("Console: a program is waiting for a key and there is no "
+                   "window for one to arrive at.\n"
+                   "Run it where there is a compositor, or give it something "
+                   "to work with through TOSEMU_KEYS.\n");
+            fflush(stdout);
+
+            halt_execution();
+            exit(1);
+        }
+
+        waiting.fd = fd;
+        waiting.events = POLLIN;
+        waiting.revents = 0;
+
+        poll(&waiting, 1, -1);
+
+        gfx_dispatch();
+    }
+}
+
+static uint32_t terminal_key(int wait)
+{
+    int ch = terminal_byte(wait);
+
+    if (ch >= 0)
+        return (uint32_t)ch;
+
+    /*
+     * Nothing, and nothing that could ever arrive: the input has ended and a
+     * program that will not go on without a key would sit here for ever. Said
+     * and stopped, for the reason evnt_multi says its version.
+     */
+    if (wait && c.ended)
+    {
+        printf("Console: a program is waiting for a key and the input has "
+               "ended, so no key can arrive.\n"
+               "Give it something on standard input, or run it where there "
+               "is a compositor to type at.\n");
+        fflush(stdout);
+
+        halt_execution();
+        exit(1);
+    }
+
+    return 0;
+}
+
+uint32_t console_key(int wait)
+{
+    decide();
+
+    /* Whatever was written is on the screen before anybody is asked to answer
+     * it, which for the terminal means out of the buffer it is sitting in */
+    if (!c.on_screen)
+        fflush(stdout);
+
+    return c.on_screen ? screen_key(wait) : terminal_key(wait);
+}
+
+int console_ready(void)
+{
+    decide();
+
+    if (!c.on_screen)
+        return terminal_ready();
+
+    if (c.stale)
+        screen_show(0);
+
+    gfx_dispatch_ready();
+
+    return gfx_key_ready();
+}
+
+/*
+ * A line, with the editing GEMDOS did for Cconrs.
+ *
+ * On an ST this was the BDOS reading keys one at a time and drawing what it
+ * read, which is why a program that wanted the line editing got it on the
+ * screen the console was on. Here it is the same loop for the same reason:
+ * neither console has a kernel behind it doing this, the terminal least of
+ * all now that it is in cbreak.
+ *
+ * Backspace rubs a character out, Return ends the line, and Ctrl-U throws the
+ * line away - which is what an ST did with Ctrl-X, but a person on a terminal
+ * has spent thirty years pressing Ctrl-U and both are free.
+ */
+int console_line(char *buffer, int max)
+{
+    int length = 0;
+
+    if (max <= 0)
+        return 0;
+
+    for (;;)
+    {
+        uint32_t key = console_key(1);
+        int ch = key & 0xff;
+
+        if (ch == '\r' || ch == '\n')
+        {
+            /* The line ends on the screen as well, or whatever is written
+             * next carries on along the same row */
+            console_out('\r');
+            console_out('\n');
+            break;
+        }
+
+        if (ch == '\b' || ch == 0x7f)
+        {
+            if (length > 0)
+            {
+                length--;
+                console_out('\b');
+                console_out(' ');
+                console_out('\b');
+            }
+            continue;
+        }
+
+        if (ch == 0x15)         /* Ctrl-U */
+        {
+            while (length > 0)
+            {
+                length--;
+                console_out('\b');
+                console_out(' ');
+                console_out('\b');
+            }
+            continue;
+        }
+
+        /* Anything else that is not a character is a key with no character -
+         * an arrow, a function key - and there is nothing to put in a line */
+        if (ch < ' ')
+            continue;
+
+        if (length >= max)
+            continue;
+
+        buffer[length++] = (char)ch;
+        console_out(ch);
+    }
+
+    return length;
+}
+
+int16_t console_cursor(int16_t function, int16_t operand)
+{
+    decide();
+
+    /*
+     * The terminal has a cursor of its own and it is not this one. Turning it
+     * off would be reaching into somebody's terminal on behalf of a program
+     * that meant its own screen, so the blink rate is remembered - which is
+     * the one thing Cursconf can be asked as well as told - and the rest is
+     * accepted and discarded.
+     */
+    if (!c.on_screen)
+    {
+        static int16_t rate = 30;
+
+        if (function == 4)
+            rate = operand;
+
+        return (function == 5) ? rate : 0;
+    }
+
+    return emuvdi_console_cursor(function, operand);
+}
+
+struct surface *console_showing(void)
+{
+    return c.up ? c.shows : 0;
+}
+
+void console_settle(void)
+{
+    if (!c.up)
+        return;
+
+    /*
+     * The application is waiting for GEM again, so it has finished with the
+     * console. On an ST this is where its own redraw covered the text over.
+     *
+     * What is drawn is left where it is rather than cleared, so a program that
+     * goes back to the console carries on where it left off - which is what an
+     * ST did, the text being on a screen nobody had erased.
+     */
+    if (c.windowed)
+        gfx_console_close();
+
+    c.windowed = 0;
+    c.up = 0;
+    c.seen = emuvdi_console_written();
+}
+
+void console_forget(void)
+{
+    /*
+     * A child of fork has a copy of the parent's console and owns none of it.
+     * The window belongs to the parent and gfx_forget has already let go of
+     * the connection it was on, so there is nothing here to close - only the
+     * copy of the surface to give back, and the decision to make again, this
+     * being a different program from now on.
+     */
+    if (c.shows)
+        surface_free(c.shows);
+
+    c.shows = 0;
+    c.up = 0;
+    c.windowed = 0;
+    c.seen = 0;
+    c.shown_at = 0;
+    c.stale = 0;
+
+    c.decided = 0;
+    c.on_screen = 0;
+
+    /*
+     * The terminal is not forgotten with the rest. It belongs to the process
+     * rather than to the program, and this process shares it with the one that
+     * forked - so what it looked like before anybody touched it is still what
+     * it has to be put back to, and an input that has ended has ended for both.
+     */
+}
+
+void console_close(void)
+{
+    console_finish();
+
+    if (c.windowed)
+        gfx_console_close();
+
+    if (c.shows)
+        surface_free(c.shows);
+
+    memset(&c, 0, sizeof c);
+}

--- a/src/console.h
+++ b/src/console.h
@@ -1,0 +1,102 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef CONSOLE_H
+#define CONSOLE_H
+
+#include <stdint.h>
+
+/*
+ * The console: the screen an application writes text on and the keyboard it
+ * reads that text back from.
+ *
+ * On an ST these were the machine's own screen and keyboard, reached through
+ * the VT52 in the BIOS, and they were the same screen GEM drew on. A program
+ * that was both - an assembler with a GEM editor round it, a compiler run from
+ * a shell - wrote its output over the desktop, waited for a key and left the
+ * application to redraw. That is not an unusual thing for a program of the
+ * period to do; it is what most development software did.
+ *
+ * There are two places it can go here and the difference is not a preference.
+ * With a compositor there is a window to put a console in, and that is the
+ * faithful answer: the text is drawn with the machine's own font, in the Atari
+ * character set, with the escape sequences meaning what they meant. Without
+ * one there is the terminal the emulator was started from, which is where
+ * every console program's output has always gone and where a test reads it.
+ *
+ * Both are the same console as far as an application is concerned. Everything
+ * below answers the same way whichever is underneath, which is the point:
+ * nothing in GEMDOS or the BIOS has to know which one this is.
+ */
+
+/* A byte to the console. The VT52 reads it, so an escape sequence written a
+ * byte at a time works the way one written whole does. */
+void console_out(int ch);
+
+/* Whether a key is waiting, which is what Cconis and Bconstat answer */
+int console_ready(void);
+
+/*
+ * The next key, as GEMDOS reports one: the character in the low byte and the
+ * IKBD scan code in bits 16 to 23.
+ *
+ * Waits for one when wait is set. Without it, 0 comes back when there is
+ * nothing there, which is what Crawio(0xff) is for.
+ */
+uint32_t console_key(int wait);
+
+/* And a line of them, with the editing GEMDOS did: Cconrs. Answers how many
+ * characters were read. */
+int console_line(char *buffer, int max);
+
+/* The cursor, which is XBIOS Cursconf */
+int16_t console_cursor(int16_t function, int16_t operand);
+
+/*
+ * What the console has on it, while it is what somebody is looking at, and
+ * nothing the rest of the time.
+ *
+ * A screenshot is of whatever is on top - a menu over a dialog over the screen
+ * - and a console is above all of those while it is up, being what the program
+ * dropped to. This is how gem_present is told so, and it is also how the
+ * console is looked at on a machine with no desktop to look at it on.
+ */
+struct surface;
+struct surface *console_showing(void);
+
+/*
+ * The application has gone back to waiting for GEM, so whatever it had to say
+ * on the console has been said.
+ *
+ * A console window is taken away here rather than when the last character was
+ * written, because a program writing to the console is not finished with it
+ * until it stops. On an ST this is where the application redrew its windows
+ * over the text; here the text has a window of its own and the window goes.
+ */
+void console_settle(void);
+
+/* Everything a child of fork inherited and owns none of - see gem_forget */
+void console_forget(void);
+
+/* And the end of the run: the window taken away and the terminal put back the
+ * way it was found */
+void console_close(void);
+
+#endif /* CONSOLE_H */

--- a/src/emuvdi/README
+++ b/src/emuvdi/README
@@ -129,6 +129,7 @@ normal_blit
 
 This is one of the two files here that replace EmuTOS code rather than adapting
 it, and conout.c below is the other.
+
 vdi_textblit.c calls normal_blit to put a character on the screen, and EmuTOS
 has it in vdi_tblit.S and a ColdFire variant of that, with no C behind either.
 The other three routines the same comment calls assembler - outline, rotate and
@@ -185,8 +186,15 @@ font_set_default, in fonts.c, has to be run again whenever the console's surface
 is selected: it works the cell metrics out from v_lin_wr, which describes
 whichever surface was selected last.
 
+It also keeps a copy of the characters beside the pixels, a byte to a cell.
+Nothing here reads that back to decide anything - it is what makes the text in a
+console window selectable, and there is no other way to know what a cell says.
+It has to follow every write, every blanking and every scroll, or what is copied
+off the console is the text as it stood before the screen last moved.
+
 bin/vditest draws through it and is the only check there is, exactly as for
-normal_blit.
+normal_blit. It prints the text read back beside the picture of the same screen,
+so that the two disagreeing is what a mistake in either looks like.
 
 
 Pointers in thirty two bit fields

--- a/src/emuvdi/README
+++ b/src/emuvdi/README
@@ -23,6 +23,13 @@ The drawing files, compiled as they stand, about ten thousand lines:
 
 and the Atari ST system fonts, bios/fnt_st_*.c with their offset tables.
 
+bios/vt52.c comes across as well, which is the console rather than the VDI: the
+state machine that reads a byte and decides whether it is a character, a control
+code or part of an escape sequence, and where the cursor goes for each. It calls
+down to six routines in bios/conout.c, and those are written here - see
+conout.c below. See also src/console.h, which is what the rest of tosemu talks
+to.
+
 Not used, because they are the parts a hosted VDI has to answer for itself:
 
     vdi_main.c                 nothing: it is the freestanding boot, but the
@@ -111,6 +118,8 @@ What is here
                  machine sold in a given country should have
     textblit.c   normal_blit, the one part of the VDI written here rather than
                  adapted - see below
+    conout.c     putting a character in a cell, which is the console's half of
+                 the same problem - see below
     vditest.c    draws into a surface and prints it, so that the port is
                  checked by looking at pixels rather than at whether it built
 
@@ -118,7 +127,8 @@ What is here
 normal_blit
 -----------
 
-This is the only file here that replaces EmuTOS code rather than adapting it.
+This is one of the two files here that replace EmuTOS code rather than adapting
+it, and conout.c below is the other.
 vdi_textblit.c calls normal_blit to put a character on the screen, and EmuTOS
 has it in vdi_tblit.S and a ColdFire variant of that, with no C behind either.
 The other three routines the same comment calls assembler - outline, rotate and
@@ -140,6 +150,43 @@ Reads have to be clamped to the glyph. A font is a strip, so the bits either
 side of a character are its neighbours rather than blank, and skew reads to the
 left of the glyph. Without the clamp the lean is drawn out of whichever
 character happens to precede it, which is what the fringe masks were for.
+
+
+conout
+------
+
+The other replaced file, and the same reason as textblit.c: the byte-in-word
+order.
+
+bios/vt52.c above is the console proper - the escape sequences, the cursor, the
+scrolling - and it is taken as it stands, because none of it touches memory. It
+calls six routines to do that: ascii_out, move_cursor, invert_cell, blank_out,
+scroll_up and scroll_down, all in bios/conout.c, and those are what is written
+here instead.
+
+The original addresses a character cell as a byte. A word of a plane holds
+sixteen pixels, which is two cells of an eight wide font, so an even cell is the
+first byte of the word and an odd one the second - true on a machine where the
+first byte of a word is its top half. Surfaces here are host endian, so the two
+halves are the other way round and every pair of characters comes out swapped.
+It compiles, it runs, and it prints ABCDEFGH as BADCFEHG.
+
+So this works in words and masks off the half it wants, which is right either
+way round. The rest is EmuTOS's arrangement kept unchanged, because vt52.c is
+written to it: what the four combinations of foreground and background bit do to
+a plane, the cursor drawn by inverting the cell it sits on rather than by
+remembering what was underneath, and where a scroll leaves the blank row.
+
+Two things are worth knowing before touching it. The cursor's position and the
+place the cursor is currently *shown* are not the same variable - move_cursor
+updates the coordinates and then erases the old one - which the original keeps
+in v_cur_ad, an address, and this keeps as a pair of cell coordinates. And
+font_set_default, in fonts.c, has to be run again whenever the console's surface
+is selected: it works the cell metrics out from v_lin_wr, which describes
+whichever surface was selected last.
+
+bin/vditest draws through it and is the only check there is, exactly as for
+normal_blit.
 
 
 Pointers in thirty two bit fields

--- a/src/emuvdi/bridge.c
+++ b/src/emuvdi/bridge.c
@@ -78,6 +78,18 @@ void emuvdi_init()
     host_font_init();
 
     /*
+     * The palette, which is the machine's rather than any workstation's.
+     *
+     * EmuTOS sets it up in v_opnwk, because on an ST nothing could draw before
+     * a workstation was open. Here the console can: a program that has never
+     * called GEM in its life still writes on a screen, and with every register
+     * still nought that screen is black text on black. So the machine has the
+     * colours an ST powered up with before anybody asks for a workstation, and
+     * v_opnwk sets them again when one is opened, which is the same values.
+     */
+    init_colors();
+
+    /*
      * And the fonts on the disk, which are GDOS's half of it.
      *
      * The device number is the one the AES is about to open the physical
@@ -116,6 +128,54 @@ void emuvdi_surface_select(void *base, uint16_t width, uint16_t height,
                            uint16_t planes)
 {
     host_surface_select(base, width, height, planes);
+}
+
+/* The console: EmuTOS's VT52 in bios/vt52.c, drawing through conout.c */
+void vt52_init(void);
+void cputc(WORD ch);
+WORD cursconf(WORD function, WORD operand);
+
+/* Which font it writes in and how large a grid that makes, in fonts.c */
+void font_set_default(void);
+
+/* And what it has actually put on the surface, in conout.c */
+extern ULONG host_console_written;
+
+/*
+ * Readies the console against whatever surface is selected.
+ *
+ * The grid is worked out from the surface, so this has to happen after one is
+ * selected and again if a different one ever becomes the console's. It clears
+ * the surface as its last act, which is what an ST's console did when the
+ * machine started.
+ */
+void emuvdi_console_init(void)
+{
+    vt52_init();
+}
+
+/*
+ * One byte to the console.
+ *
+ * The cell metrics are worked out again first because they are derived from
+ * v_lin_wr, which describes whichever surface was selected last - and between
+ * one character and the next the VDI may well have drawn somewhere else.
+ */
+void emuvdi_console_out(int ch)
+{
+    font_set_default();
+
+    cputc((WORD)ch);
+}
+
+int16_t emuvdi_console_cursor(int16_t function, int16_t operand)
+{
+    return cursconf(function, operand);
+}
+
+unsigned long emuvdi_console_written(void)
+{
+    return (unsigned long)host_console_written;
 }
 
 /* The AES's own resource, aes/gem_rsc.c */

--- a/src/emuvdi/bridge.c
+++ b/src/emuvdi/bridge.c
@@ -138,8 +138,13 @@ WORD cursconf(WORD function, WORD operand);
 /* Which font it writes in and how large a grid that makes, in fonts.c */
 void font_set_default(void);
 
-/* And what it has actually put on the surface, in conout.c */
+/* And what it has actually put on the surface, in conout.c, along with what it
+ * says and where the cells are */
 extern ULONG host_console_written;
+
+void host_console_cells(int *cols, int *rows, int *width, int *height);
+int host_console_text(int ax, int ay, int bx, int by, char *out, int size);
+void invert_cell(int x, int y);
 
 /*
  * Readies the console against whatever surface is selected.
@@ -176,6 +181,36 @@ int16_t emuvdi_console_cursor(int16_t function, int16_t operand)
 unsigned long emuvdi_console_written(void)
 {
     return (unsigned long)host_console_written;
+}
+
+void emuvdi_console_cells(int16_t *cols, int16_t *rows,
+                          int16_t *width, int16_t *height)
+{
+    int c, r, w, h;
+
+    font_set_default();
+
+    host_console_cells(&c, &r, &w, &h);
+
+    *cols = (int16_t)c;
+    *rows = (int16_t)r;
+    *width = (int16_t)w;
+    *height = (int16_t)h;
+}
+
+int emuvdi_console_text(int16_t ax, int16_t ay, int16_t bx, int16_t by,
+                        char *out, int size)
+{
+    font_set_default();
+
+    return host_console_text(ax, ay, bx, by, out, size);
+}
+
+void emuvdi_console_invert(int16_t cx, int16_t cy)
+{
+    font_set_default();
+
+    invert_cell(cx, cy);
 }
 
 /* The AES's own resource, aes/gem_rsc.c */

--- a/src/emuvdi/conout.c
+++ b/src/emuvdi/conout.c
@@ -1,0 +1,407 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * Putting characters in cells, which is the half of the console that knows
+ * what a screen is made of.
+ *
+ * The VT52 above it - which escape means what, where the cursor goes, when the
+ * screen scrolls - is EmuTOS's bios/vt52.c, compiled out of the submodule and
+ * unedited. This is bios/conout.c, and it is the second file here that
+ * replaces EmuTOS code rather than adapting it, for the same reason as the
+ * first: byte order.
+ *
+ * The original addresses a cell as a byte. A word of a plane holds sixteen
+ * pixels, which is two cells of an eight wide font, so an even cell is the
+ * first byte of the word and an odd one the second - on a machine where the
+ * first byte of a word is its top half. Surfaces here are host endian, which
+ * is what lets the rest of the VDI go unedited, so the two halves are the
+ * other way round and every pair of characters would come out swapped. The
+ * same trap CONF_WITH_VDI_TEXT_SPEEDUP is turned off for; see the README.
+ *
+ * So this works in words and masks off the half it wants, which is right
+ * either way round. Everything else about it - what the four combinations of
+ * foreground and background bit do to a plane, how the cursor is drawn by
+ * inverting the cell it sits on, what a scroll leaves behind - is EmuTOS's
+ * arrangement, kept because vt52.c above is written to it.
+ */
+
+#include "emutos.h"
+#include "asm.h"
+#include "intmath.h"
+#include "tosvars.h"
+#include "vdi_defs.h"
+#include "lineavars.h"
+#include "conout.h"
+
+#include <string.h>
+
+/*
+ * The console's own line-A variables.
+ *
+ * hostvars.c has the ones the VDI draws through, including the cell metrics,
+ * because the VDI's escape functions keep track of where a text cursor would
+ * be even though a hosted VDI has no console. These are the ones only a
+ * console uses, so they live beside the code that uses them.
+ */
+UBYTE *v_cur_ad;                /* the cell the cursor is on */
+WORD v_cur_of;                  /* how far down the screen the first row is */
+UBYTE v_cur_tim;                /* ticks until the cursor next changes state */
+UBYTE v_period;                 /* and how many there are between changes */
+WORD disab_cnt;                 /* how deep the cursor is turned off */
+UBYTE v_stat_0;                 /* the cursor and video state bits */
+WORD sav_cur_x;                 /* where ESC j put the cursor */
+WORD sav_cur_y;
+WORD v_col_fg;                  /* the colours characters are drawn in */
+WORD v_col_bg;
+
+/* The font, which font_set_default in fonts.c chooses and fills in */
+const UWORD *v_fnt_ad;
+const UWORD *v_off_ad;
+UWORD v_fnt_st;
+UWORD v_fnt_nd;
+UWORD v_fnt_wr;
+
+/*
+ * The three the console keeps in EmuTOS's system variable page rather than in
+ * line-A. con_state is the VT52's state machine - which of its handlers reads
+ * the next byte - and it is what vt52.c drives itself through.
+ *
+ * conterm is the keyboard and console settings byte. Bit 2 is what says
+ * whether the bell rings, and nothing here sets any of the others, so it
+ * starts as an ST's does: key click, key repeat and the bell all on.
+ */
+void (*con_state)(WORD);
+WORD save_row;
+UBYTE conterm = 0x07;
+
+/*
+ * How many characters have actually appeared on the console.
+ *
+ * This is not bookkeeping the console needs; it is what says whether there is
+ * anything to look at. A program that writes an escape sequence and nothing
+ * else has written to the console and said nothing, and opening a window to
+ * show the result would be a window with nothing in it - see screen_show in
+ * console.c, which is the only reader.
+ */
+ULONG host_console_written;
+
+/*
+ * The bell, which on an ST was the sound chip.
+ *
+ * There is no sound chip and there is not going to be one, so this is the
+ * terminal's bell instead. It goes to stderr rather than to the console
+ * because the console is a screen, and a character written on it would be a
+ * character an application did not ask for.
+ */
+void bell(void)
+{
+    /* Nothing yet. A GEM application that rings it is asking for a noise
+     * tosemu has nowhere to make, and printing something would be worse than
+     * silence. */
+}
+
+/* How many words a row of the surface is, which is what v_lin_wr says in
+ * bytes. Every screen is a whole number of words across - see surface.c - so
+ * this divides exactly. */
+static int words_per_line(void)
+{
+    return v_lin_wr / 2;
+}
+
+/* The first word of a cell, which is the pair of cells the cell is half of */
+static UWORD *cell_word(int cx, int y)
+{
+    UWORD *base = (UWORD *)v_bas_ad;
+
+    return base + (size_t)y * words_per_line() + (cx >> 1) * v_planes;
+}
+
+/* And which half of it this cell is. An even cell is the leftmost eight
+ * pixels of the word, which is its top half whatever the host's byte order
+ * does with the two. */
+static int cell_shift(int cx)
+{
+    return IS_ODD(cx) ? 0 : 8;
+}
+
+/*
+ * One row of one cell, given the eight bits of the glyph on that row.
+ *
+ * The four cases EmuTOS's cell_xfer names are here as arithmetic rather than
+ * as branches: a plane where the foreground colour has a bit set takes the
+ * glyph, a plane where the background has one takes its inverse, a plane with
+ * both takes all ones and a plane with neither takes all noughts.
+ */
+static void row_put(int cx, int y, UBYTE bits, UWORD fg, UWORD bg)
+{
+    UWORD *word = cell_word(cx, y);
+    int shift = cell_shift(cx);
+    UWORD mask = (UWORD)(0x00ffu << shift);
+    int plane;
+
+    for (plane = 0; plane < v_planes; plane++)
+    {
+        UBYTE value = (UBYTE)((((fg >> plane) & 1) ? bits : 0)
+                              | (((bg >> plane) & 1) ? (UBYTE)~bits : 0));
+
+        word[plane] = (UWORD)((word[plane] & ~mask)
+                              | (((UWORD)value << shift) & mask));
+    }
+}
+
+/* And the same row inverted, which is how the cursor is drawn: a second
+ * inversion puts back what was underneath, so nothing has to be remembered */
+static void row_invert(int cx, int y)
+{
+    UWORD *word = cell_word(cx, y);
+    UWORD mask = (UWORD)(0x00ffu << cell_shift(cx));
+    int plane;
+
+    for (plane = 0; plane < v_planes; plane++)
+        word[plane] ^= mask;
+}
+
+/*
+ * The eight bits of a character on one row of its cell.
+ *
+ * A font is one long strip of glyphs rather than a glyph at a time, so a
+ * character is found by where along the row it starts. The offset table says
+ * that in pixels, and the strip is read a word at a time - as the VDI reads
+ * it - so which half of the word holds the character is the same question as
+ * for a cell, and has the same answer.
+ */
+static UBYTE glyph_row(WORD ch, int row)
+{
+    UWORD offset;
+    UWORD word;
+
+    if (ch < v_fnt_st || ch > v_fnt_nd || !v_fnt_ad || !v_off_ad)
+        return 0;
+
+    offset = v_off_ad[ch];
+
+    word = v_fnt_ad[row * (v_fnt_wr / 2) + (offset >> 4)];
+
+    return (UBYTE)((offset & 8) ? (word & 0xff) : (word >> 8));
+}
+
+void invert_cell(int x, int y)
+{
+    int row;
+
+    if (x < 0 || y < 0 || x > v_cel_mx || y > v_cel_my)
+        return;
+
+    for (row = 0; row < v_cel_ht; row++)
+        row_invert(x, y * v_cel_ht + row);
+}
+
+/*
+ * Where the cursor is being shown, which is not always where it is.
+ *
+ * move_cursor updates the coordinates first and then erases the cursor from
+ * where it was, so the old place has to be remembered somewhere. EmuTOS keeps
+ * it in v_cur_ad, which is an address into the screen; the addressing here is
+ * done from coordinates, so these are the coordinates. v_cur_ad is kept
+ * pointing at the same cell for anything that reads it.
+ */
+static WORD shown_cx;
+static WORD shown_cy;
+
+static void cursor_shown_at(int x, int y)
+{
+    shown_cx = x;
+    shown_cy = y;
+
+    v_cur_ad = (UBYTE *)cell_word(x, y * v_cel_ht);
+}
+
+void move_cursor(int x, int y)
+{
+    if (x < 0)
+        x = 0;
+    else if (x > v_cel_mx)
+        x = v_cel_mx;
+
+    if (y < 0)
+        y = 0;
+    else if (y > v_cel_my)
+        y = v_cel_my;
+
+    v_cur_cx = x;
+    v_cur_cy = y;
+
+    /* Nothing to move if nothing is being shown */
+    if (!(v_stat_0 & M_CVIS))
+    {
+        cursor_shown_at(x, y);
+        return;
+    }
+
+    /* A cursor that flashes and happens to be in its off half is not on the
+     * screen to be erased, so it is simply drawn in the new place */
+    if (v_stat_0 & M_CFLASH)
+    {
+        v_stat_0 &= ~M_CVIS;
+
+        if (!(v_stat_0 & M_CSTATE))
+        {
+            cursor_shown_at(x, y);
+            invert_cell(x, y);
+            v_stat_0 |= M_CSTATE;
+            v_cur_tim = v_period;
+            v_stat_0 |= M_CVIS;
+            return;
+        }
+    }
+
+    invert_cell(shown_cx, shown_cy);
+    cursor_shown_at(x, y);
+    invert_cell(x, y);
+
+    /* A cursor that has just moved is shown solidly for a moment, so that
+     * something moving does not disappear as it arrives */
+    v_cur_tim = v_period;
+
+    v_stat_0 |= M_CVIS;
+}
+
+void ascii_out(int ch)
+{
+    UWORD fg, bg;
+    int visible;
+    int row;
+
+    if (ch < v_fnt_st || ch > v_fnt_nd)
+        return;
+
+    /* Reverse video swaps the two, which is the whole of what it is */
+    if (v_stat_0 & M_REVID)
+    {
+        fg = v_col_bg;
+        bg = v_col_fg;
+    }
+    else
+    {
+        fg = v_col_fg;
+        bg = v_col_bg;
+    }
+
+    visible = v_stat_0 & M_CVIS;
+    if (visible)
+        v_stat_0 &= ~M_CVIS;
+
+    for (row = 0; row < v_cel_ht; row++)
+        row_put(v_cur_cx, v_cur_cy * v_cel_ht + row, glyph_row(ch, row),
+                fg, bg);
+
+    host_console_written++;
+
+    /*
+     * Where the next character goes.
+     *
+     * A character written in the last column does not move the cursor unless
+     * wrapping is on, which is what stops the screen scrolling every time
+     * something fills the bottom row exactly.
+     */
+    if (v_cur_cx == v_cel_mx)
+    {
+        if (v_stat_0 & M_CEOL)
+        {
+            v_cur_cx = 0;
+
+            if (v_cur_cy < v_cel_my)
+                v_cur_cy++;
+            else
+                scroll_up(0);
+        }
+    }
+    else
+        v_cur_cx++;
+
+    cursor_shown_at(v_cur_cx, v_cur_cy);
+
+    if (visible)
+    {
+        invert_cell(v_cur_cx, v_cur_cy);
+        v_stat_0 |= M_CSTATE;
+        v_stat_0 |= M_CVIS;
+
+        if (v_stat_0 & M_CFLASH)
+            v_cur_tim = v_period;
+    }
+}
+
+/*
+ * Fills cells with the background colour, from one corner to another.
+ *
+ * EmuTOS requires the left column to be even and the right one odd, because
+ * it works in whole words and says so in a comment. Nothing here does: a cell
+ * is masked into its half of the word, so either end may be either. The
+ * callers in vt52.c go on obeying the rule and the result is the same.
+ */
+void blank_out(int topx, int topy, int botx, int boty)
+{
+    int x, y, row;
+
+    if (topx < 0)
+        topx = 0;
+    if (topy < 0)
+        topy = 0;
+    if (botx > v_cel_mx)
+        botx = v_cel_mx;
+    if (boty > v_cel_my)
+        boty = v_cel_my;
+
+    for (y = topy; y <= boty; y++)
+        for (row = 0; row < v_cel_ht; row++)
+            for (x = topx; x <= botx; x++)
+                row_put(x, y * v_cel_ht + row, 0, 0, v_col_bg);
+}
+
+/*
+ * Moving the screen up by a row, and down by one.
+ *
+ * These are whole rows of whole words, so they are a move of memory and the
+ * byte order underneath it never comes into it. That is why they are EmuTOS's
+ * code with only the pointer arithmetic spelled out.
+ */
+void scroll_up(UWORD top_line)
+{
+    UBYTE *dst = v_bas_ad + (ULONG)top_line * v_cel_wr;
+    UBYTE *src = dst + v_cel_wr;
+    ULONG count = (ULONG)v_cel_wr * (v_cel_my - top_line);
+
+    memmove(dst, src, count);
+
+    blank_out(0, v_cel_my, v_cel_mx, v_cel_my);
+}
+
+void scroll_down(UWORD start_line)
+{
+    UBYTE *src = v_bas_ad + (ULONG)start_line * v_cel_wr;
+    UBYTE *dst = src + v_cel_wr;
+    ULONG count = (ULONG)v_cel_wr * (v_cel_my - start_line);
+
+    memmove(dst, src, count);
+
+    blank_out(0, start_line, v_cel_mx, start_line);
+}

--- a/src/emuvdi/conout.c
+++ b/src/emuvdi/conout.c
@@ -51,6 +51,7 @@
 #include "lineavars.h"
 #include "conout.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 /*
@@ -102,6 +103,155 @@ UBYTE conterm = 0x07;
  * console.c, which is the only reader.
  */
 ULONG host_console_written;
+
+/*
+ * What is on the console, a character to a cell.
+ *
+ * Everything below draws pixels, and pixels are not something the text can be
+ * got back out of: a cell holding an A is eight by sixteen bits that happen to
+ * look like one, and working out which character that was would mean comparing
+ * it against every glyph in the font. So the characters are kept beside them as
+ * they are drawn.
+ *
+ * It is not the console's own bookkeeping - nothing here reads it back to
+ * decide anything. It is what makes the text selectable, which is the whole
+ * reason for it: a person can drag across the console window and copy what it
+ * says, and there is no other way to know what it says.
+ *
+ * The grid is as large as the cells the font and the surface work out to, and
+ * it follows them: a console on a different screen has a different shape, and
+ * grid_fit is where that is noticed.
+ */
+static UBYTE *grid;
+static int grid_cols;
+static int grid_rows;
+
+static void grid_fit(void)
+{
+    int cols = v_cel_mx + 1;
+    int rows = v_cel_my + 1;
+
+    if (cols == grid_cols && rows == grid_rows)
+        return;
+
+    free(grid);
+
+    grid = 0;
+    grid_cols = 0;
+    grid_rows = 0;
+
+    if (cols <= 0 || rows <= 0)
+        return;
+
+    grid = malloc((size_t)cols * rows);
+    if (!grid)
+        return;
+
+    /* Spaces rather than noughts, so that a cell nothing has been written to
+     * reads back as the blank it looks like */
+    memset(grid, ' ', (size_t)cols * rows);
+
+    grid_cols = cols;
+    grid_rows = rows;
+}
+
+static void grid_put(int cx, int cy, UBYTE ch)
+{
+    if (!grid || cx < 0 || cy < 0 || cx >= grid_cols || cy >= grid_rows)
+        return;
+
+    grid[(size_t)cy * grid_cols + cx] = ch;
+}
+
+/* How the console is laid out, for whoever has to turn a place the pointer was
+ * into a cell */
+void host_console_cells(int *cols, int *rows, int *width, int *height)
+{
+    grid_fit();
+
+    *cols = grid_cols;
+    *rows = grid_rows;
+
+    /* Which is max_cell_width, worked out the way font_set_default worked the
+     * column count out of it */
+    *width = grid_cols ? (V_REZ_HZ / grid_cols) : 0;
+    *height = v_cel_ht;
+}
+
+/*
+ * What the console says between two cells, in reading order, spelled the way an
+ * ST spells text: CR LF between lines.
+ *
+ * Trailing spaces on a line are dropped, because a console line is padded out
+ * to the width of the screen with blanks nobody typed - a selection three lines
+ * tall would otherwise come back with a hundred and fifty spaces in it.
+ *
+ * Answers how many characters were written, and NUL terminates when there is
+ * room for it.
+ */
+int host_console_text(int ax, int ay, int bx, int by, char *out, int size)
+{
+    int length = 0;
+    int y;
+
+    grid_fit();
+
+    if (!grid || size <= 0)
+        return 0;
+
+    /* Reading order, whichever end the drag started at */
+    if (ay > by || (ay == by && ax > bx))
+    {
+        int t;
+
+        t = ax; ax = bx; bx = t;
+        t = ay; ay = by; by = t;
+    }
+
+    if (ay < 0)
+        ay = 0;
+    if (by >= grid_rows)
+        by = grid_rows - 1;
+
+    for (y = ay; y <= by; y++)
+    {
+        /* A middle line runs the whole width; the first starts where the drag
+         * did and the last ends where it ended */
+        int from = (y == ay) ? ax : 0;
+        int to = (y == by) ? bx : grid_cols - 1;
+        int x;
+
+        if (from < 0)
+            from = 0;
+        if (to >= grid_cols)
+            to = grid_cols - 1;
+
+        while (to >= from && grid[(size_t)y * grid_cols + to] == ' ')
+            to--;
+
+        for (x = from; x <= to; x++)
+        {
+            if (length >= size)
+                return length;
+
+            out[length++] = (char)grid[(size_t)y * grid_cols + x];
+        }
+
+        if (y == by)
+            break;
+
+        if (length + 2 > size)
+            return length;
+
+        out[length++] = '\r';
+        out[length++] = '\n';
+    }
+
+    if (length < size)
+        out[length] = 0;
+
+    return length;
+}
 
 /*
  * The bell, which on an ST was the sound chip.
@@ -313,6 +463,9 @@ void ascii_out(int ch)
         row_put(v_cur_cx, v_cur_cy * v_cel_ht + row, glyph_row(ch, row),
                 fg, bg);
 
+    grid_fit();
+    grid_put(v_cur_cx, v_cur_cy, (UBYTE)ch);
+
     host_console_written++;
 
     /*
@@ -371,10 +524,17 @@ void blank_out(int topx, int topy, int botx, int boty)
     if (boty > v_cel_my)
         boty = v_cel_my;
 
+    grid_fit();
+
     for (y = topy; y <= boty; y++)
+    {
         for (row = 0; row < v_cel_ht; row++)
             for (x = topx; x <= botx; x++)
                 row_put(x, y * v_cel_ht + row, 0, 0, v_col_bg);
+
+        for (x = topx; x <= botx; x++)
+            grid_put(x, y, ' ');
+    }
 }
 
 /*
@@ -392,6 +552,15 @@ void scroll_up(UWORD top_line)
 
     memmove(dst, src, count);
 
+    /* And the characters with them, or what is copied back off the console
+     * would be the text as it stood before the screen moved */
+    grid_fit();
+
+    if (grid && top_line < (UWORD)grid_rows)
+        memmove(grid + (size_t)top_line * grid_cols,
+                grid + (size_t)(top_line + 1) * grid_cols,
+                (size_t)(grid_rows - 1 - top_line) * grid_cols);
+
     blank_out(0, v_cel_my, v_cel_mx, v_cel_my);
 }
 
@@ -402,6 +571,13 @@ void scroll_down(UWORD start_line)
     ULONG count = (ULONG)v_cel_wr * (v_cel_my - start_line);
 
     memmove(dst, src, count);
+
+    grid_fit();
+
+    if (grid && start_line < (UWORD)grid_rows)
+        memmove(grid + (size_t)(start_line + 1) * grid_cols,
+                grid + (size_t)start_line * grid_cols,
+                (size_t)(grid_rows - 1 - start_line) * grid_cols);
 
     blank_out(0, start_line, v_cel_mx, start_line);
 }

--- a/src/emuvdi/emuvdi.h
+++ b/src/emuvdi/emuvdi.h
@@ -45,6 +45,31 @@ void emuvdi_surface_select(void *base, uint16_t width, uint16_t height,
                            uint16_t planes);
 
 /*
+ * The console, which is the VT52 in EmuTOS's BIOS drawing into a surface.
+ *
+ * It is here rather than beside the VDI because it is the same seam and the
+ * same three levers: EmuTOS's code, built for the host, reached without a WORD
+ * crossing over. What is on the other side is bios/vt52.c unedited and
+ * emuvdi/conout.c, which puts the characters in their cells.
+ *
+ * Readying it takes the shape of the grid from whichever surface is selected,
+ * and so does writing to it - so both want the console's surface selected
+ * first. See console.c, which owns that surface and is the only caller.
+ */
+void emuvdi_console_init(void);
+void emuvdi_console_out(int ch);
+
+/* Cursconf, XBIOS 21: whether the cursor shows, whether it blinks and how
+ * fast */
+int16_t emuvdi_console_cursor(int16_t function, int16_t operand);
+
+/*
+ * How many characters have appeared on it, which is how a console with
+ * something to show is told from one that has only been configured.
+ */
+unsigned long emuvdi_console_written(void);
+
+/*
  * Serves one VDI call.
  *
  * The five arrays are the ones the caller passed, already copied out of the

--- a/src/emuvdi/emuvdi.h
+++ b/src/emuvdi/emuvdi.h
@@ -70,6 +70,31 @@ int16_t emuvdi_console_cursor(int16_t function, int16_t operand);
 unsigned long emuvdi_console_written(void);
 
 /*
+ * And reading it back, which is what makes the text on it selectable.
+ *
+ * The console draws pixels, and a cell holding an A is eight by sixteen bits
+ * that happen to look like one - so the characters are kept beside them as
+ * they are drawn, and this is how they are got at. See conout.c.
+ *
+ * The cells say how a place the pointer was becomes a place in the text: how
+ * many there are and how large one is, in the console surface's own pixels.
+ */
+void emuvdi_console_cells(int16_t *cols, int16_t *rows,
+                          int16_t *width, int16_t *height);
+
+/*
+ * The text between two cells, in reading order and spelled the way an ST
+ * spells it - CR LF between lines, and the blanks a line is padded out with
+ * dropped. Answers how many characters were written.
+ */
+int emuvdi_console_text(int16_t ax, int16_t ay, int16_t bx, int16_t by,
+                        char *out, int size);
+
+/* And turning a cell inside out, which is how a selection is shown: the same
+ * way the cursor is, so nothing has to be remembered to put it back */
+void emuvdi_console_invert(int16_t cx, int16_t cy);
+
+/*
  * Serves one VDI call.
  *
  * The five arrays are the ones the caller passed, already copied out of the

--- a/src/emuvdi/fonts.c
+++ b/src/emuvdi/fonts.c
@@ -35,6 +35,7 @@
 #include "tosvars.h"
 #include "vdi_defs.h"
 #include "lineavars.h"
+#include "font.h"
 
 /* The fonts themselves, compiled from the submodule */
 extern const Fonthead fnt_st_6x6;
@@ -84,4 +85,34 @@ void host_font_init(void)
 
     /* Builds font_ring and def_font out of the above */
     text_init();
+}
+
+/*
+ * The font the console writes in, and the shape of the grid it writes on.
+ *
+ * EmuTOS has this in bios/font.c, which is not built here - the rest of that
+ * file asks country.c which fonts a machine sold in a given country should
+ * have, and the answer here is always the Atari ST ones. What it does is
+ * arithmetic on the header of whichever font was chosen, so it is the same
+ * arithmetic.
+ *
+ * Which font is chosen is a question about how many rows will fit: the 8x16
+ * on a screen four hundred lines tall, where twenty five rows is what a GEM
+ * program expects, and the 8x8 on anything shorter, where sixteen pixels a
+ * row would leave twelve.
+ */
+void font_set_default(void)
+{
+    Fonthead *font = (V_REZ_VT < 400) ? &fon8x8 : &fon8x16;
+
+    v_cel_ht = font->form_height;
+    v_cel_wr = v_lin_wr * font->form_height;
+    v_cel_mx = (V_REZ_HZ / font->max_cell_width) - 1;
+    v_cel_my = (V_REZ_VT / font->form_height) - 1;
+
+    v_fnt_wr = font->form_width;
+    v_fnt_st = font->first_ade;
+    v_fnt_nd = font->last_ade;
+    v_fnt_ad = font->dat_table;
+    v_off_ad = font->off_table;
 }

--- a/src/emuvdi/vditest.c
+++ b/src/emuvdi/vditest.c
@@ -170,6 +170,18 @@ static void workstation_init(void)
     LN_MASK = LINE_STYLE[vwk.line_index];
 }
 
+/* The console: bios/vt52.c out of the submodule, drawing through conout.c */
+void vt52_init(void);
+void cputc(WORD ch);
+
+static void cputs(const char *text)
+{
+    int i;
+
+    for (i = 0; text[i]; i++)
+        cputc((unsigned char)text[i]);
+}
+
 /* v_gtext as an application makes it: the string in intin, the position in
  * ptsin, and how many characters there are in the control array */
 static void gtext(WORD x, WORD y, const char *text)
@@ -307,6 +319,35 @@ int main(void)
     gtext(2, 14, "Lightened");
     vwk.style = 0;
     show("v_gtext, lightened, which screens the glyph with a mask");
+
+    /*
+     * The console, which is EmuTOS's VT52 drawing through the conout.c here.
+     *
+     * This is the only check there is on that file, and it is the same kind of
+     * check normal_blit gets above and for the same reason: the original works
+     * in bytes and puts an even cell in the first byte of a word, which is its
+     * top half on a 68000 and its bottom half here. Every pair of characters
+     * would come out swapped, which is exactly the sort of thing that compiles
+     * and runs.
+     *
+     * Eight cells across and three down, the 8x8 font being what a screen this
+     * short gets. The cursor stays off throughout: vt52_init leaves it
+     * disabled, and a block that blinks is not something a printout can show.
+     */
+    memset(surface, 0, sizeof surface);
+    vt52_init();
+    cputs("ABCDEFGH");
+    show("the console, one character in each cell of the top row");
+
+    memset(surface, 0, sizeof surface);
+    vt52_init();
+    cputs("\033Y!$Mid\033pRev");
+    show("the console, ESC Y to the middle and ESC p for reverse video");
+
+    memset(surface, 0, sizeof surface);
+    vt52_init();
+    cputs("one\r\ntwo\r\nthree\r\nfour");
+    show("the console, a fourth line on a screen three rows tall");
 
     return 0;
 }

--- a/src/emuvdi/vditest.c
+++ b/src/emuvdi/vditest.c
@@ -173,6 +173,7 @@ static void workstation_init(void)
 /* The console: bios/vt52.c out of the submodule, drawing through conout.c */
 void vt52_init(void);
 void cputc(WORD ch);
+int host_console_text(int ax, int ay, int bx, int by, char *out, int size);
 
 static void cputs(const char *text)
 {
@@ -180,6 +181,35 @@ static void cputs(const char *text)
 
     for (i = 0; text[i]; i++)
         cputc((unsigned char)text[i]);
+}
+
+/*
+ * What the console says between two cells, which is the copy of the characters
+ * conout.c keeps beside the pixels rather than anything read back off them.
+ *
+ * Printed beside the picture of the same screen on purpose: the two are made by
+ * different code from the same writes, so one of them going wrong shows up as
+ * the pair disagreeing.
+ */
+static void showtext(const char *what, int ax, int ay, int bx, int by)
+{
+    char text[256];
+    int n = host_console_text(ax, ay, bx, by, text, (int)sizeof text);
+    int i;
+
+    printf("\n%s\n   \"", what);
+
+    for (i = 0; i < n; i++)
+    {
+        if (text[i] == '\r')
+            printf("\\r");
+        else if (text[i] == '\n')
+            printf("\\n");
+        else
+            putchar(text[i]);
+    }
+
+    printf("\" (%d characters)\n", n);
 }
 
 /* v_gtext as an application makes it: the string in intin, the position in
@@ -339,6 +369,17 @@ int main(void)
     cputs("ABCDEFGH");
     show("the console, one character in each cell of the top row");
 
+    /*
+     * And the same screen read back as text, which is the copy of the
+     * characters kept beside the pixels. It is what makes the console window's
+     * text selectable, and there is no other way to know what a cell says: a
+     * cell holding an A is eight by eight bits that happen to look like one.
+     */
+    showtext("read back whole", 0, 0, 7, 0);
+    showtext("read back from the middle of the line", 2, 0, 4, 0);
+    showtext("read back to the bottom, the blank rows trimmed away",
+             0, 0, 7, 2);
+
     memset(surface, 0, sizeof surface);
     vt52_init();
     cputs("\033Y!$Mid\033pRev");
@@ -348,6 +389,14 @@ int main(void)
     vt52_init();
     cputs("one\r\ntwo\r\nthree\r\nfour");
     show("the console, a fourth line on a screen three rows tall");
+
+    /* Which the characters had to scroll for as well: read back as it stood
+     * before the screen moved, the first line would still be "one" */
+    showtext("read back after the scroll", 0, 0, 7, 2);
+
+    /* And the same range named the other way round, which is a drag made
+     * upwards - what comes back is the text, not the text backwards */
+    showtext("read back from a drag made bottom to top", 7, 2, 0, 0);
 
     return 0;
 }

--- a/src/emuvdi/vditest.expected
+++ b/src/emuvdi/vditest.expected
@@ -251,6 +251,15 @@ the console, one character in each cell of the top row
 23 |                                                                |
    +----------------------------------------------------------------+
 
+read back whole
+   "ABCDEFGH" (8 characters)
+
+read back from the middle of the line
+   "CDE" (3 characters)
+
+read back to the bottom, the blank rows trimmed away
+   "ABCDEFGH\r\n\r\n" (12 characters)
+
 the console, ESC Y to the middle and ESC p for reverse video
    +----------------------------------------------------------------+
  0 |                                                                |
@@ -306,3 +315,9 @@ the console, a fourth line on a screen three rows tall
 22 |  MM      MMMM    MMMMM  MM                                     |
 23 |                                                                |
    +----------------------------------------------------------------+
+
+read back after the scroll
+   "two\r\nthree\r\nfour" (16 characters)
+
+read back from a drag made bottom to top
+   "two\r\nthree\r\nfour" (16 characters)

--- a/src/emuvdi/vditest.expected
+++ b/src/emuvdi/vditest.expected
@@ -222,3 +222,87 @@ v_gtext, lightened, which screens the glyph with a mask
 22 |                                                                |
 23 |                                                                |
    +----------------------------------------------------------------+
+
+the console, one character in each cell of the top row
+   +----------------------------------------------------------------+
+ 0 |   MM    MMMMM    MMMM   MMMM    MMMMMM  MMMMMM   MMMMM  MM  MM |
+ 1 |  MMMM   MM  MM  MM  MM  MM MM   MM      MM      MM      MM  MM |
+ 2 | MM  MM  MM  MM  MM      MM  MM  MM      MM      MM      MM  MM |
+ 3 | MM  MM  MMMMM   MM      MM  MM  MMMMM   MMMMM   MM MMM  MMMMMM |
+ 4 | MMMMMM  MM  MM  MM      MM  MM  MM      MM      MM  MM  MM  MM |
+ 5 | MM  MM  MM  MM  MM  MM  MM MM   MM      MM      MM  MM  MM  MM |
+ 6 | MM  MM  MMMMM    MMMM   MMMM    MMMMMM  MM       MMMMM  MM  MM |
+ 7 |                                                                |
+ 8 |                                                                |
+ 9 |                                                                |
+10 |                                                                |
+11 |                                                                |
+12 |                                                                |
+13 |                                                                |
+14 |                                                                |
+15 |                                                                |
+16 |                                                                |
+17 |                                                                |
+18 |                                                                |
+19 |                                                                |
+20 |                                                                |
+21 |                                                                |
+22 |                                                                |
+23 |                                                                |
+   +----------------------------------------------------------------+
+
+the console, ESC Y to the middle and ESC p for reverse video
+   +----------------------------------------------------------------+
+ 0 |                                                                |
+ 1 |                                                                |
+ 2 |                                                                |
+ 3 |                                                                |
+ 4 |                                                                |
+ 5 |                                                                |
+ 6 |                                                                |
+ 7 |                                                                |
+ 8 |                                MM   MM    MM        MM MMMMMMMM|
+ 9 |                                MMM MMM              MM MMMMMMMM|
+10 |                                MMMMMMM   MMM     MMMMM M  MM  M|
+11 |                                MM M MM    MM    MM  MM M  MM  M|
+12 |                                MM   MM    MM    MM  MM M  MM  M|
+13 |                                MM   MM    MM    MM  MM MM    MM|
+14 |                                MM   MM   MMMM    MMMMM MMM  MMM|
+15 |                                                        MMMMMMMM|
+16 |                                                                |
+17 |                                                                |
+18 |                                                                |
+19 |                                                                |
+20 |                                                                |
+21 |                                                                |
+22 |                                                                |
+23 |                                                                |
+   +----------------------------------------------------------------+
+
+the console, a fourth line on a screen three rows tall
+   +----------------------------------------------------------------+
+ 0 |                                                                |
+ 1 |   MM                                                           |
+ 2 | MMMMMM MM   MM   MMMM                                          |
+ 3 |   MM   MM   MM  MM  MM                                         |
+ 4 |   MM   MM M MM  MM  MM                                         |
+ 5 |   MM    MMMMM   MM  MM                                         |
+ 6 |    MMM  MM MM    MMMM                                          |
+ 7 |                                                                |
+ 8 |         MM                                                     |
+ 9 |   MM    MM                                                     |
+10 | MMMMMM  MMMMM   MMMMM    MMMM    MMMM                          |
+11 |   MM    MM  MM  MM  MM  MM  MM  MM  MM                         |
+12 |   MM    MM  MM  MM      MMMMMM  MMMMMM                         |
+13 |   MM    MM  MM  MM      MM      MM                             |
+14 |    MMM  MM  MM  MM       MMMM    MMMM                          |
+15 |                                                                |
+16 |   MMM                                                          |
+17 |  MM                                                            |
+18 | MMMMM    MMMM   MM  MM  MMMMM                                  |
+19 |  MM     MM  MM  MM  MM  MM  MM                                 |
+20 |  MM     MM  MM  MM  MM  MM                                     |
+21 |  MM     MM  MM  MM  MM  MM                                     |
+22 |  MM      MMMM    MMMMM  MM                                     |
+23 |                                                                |
+   +----------------------------------------------------------------+

--- a/src/gem.c
+++ b/src/gem.c
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "console.h"
 #include "gem_p.h"
 #include "tossystem.h"
 #include "surface.h"
@@ -89,6 +90,28 @@ static struct surface *dialog;
 static struct surface *menu;
 
 static int started;
+
+/*
+ * Whether GEM has ever been started in this process or in the one that forked
+ * it, which is not the same question as whether it is up now.
+ *
+ * gem_forget clears `started`, because a child of Pexec is a program of its own
+ * and has to introduce itself to GEM again - but it is still a program a GEM
+ * application ran, and that is what this remembers. GenST's assembler is the
+ * case: it never calls GEM in its life, and it is run from inside a GEM editor
+ * that has taken the screen over.
+ *
+ * What it decides is where the console goes. A program a person started from a
+ * shell writes to that shell; one that came out of a GEM application writes on
+ * the screen, which is where an ST would have put it and where the person is
+ * looking. See console.c.
+ */
+static int ever_started;
+
+int gem_ever_started(void)
+{
+    return ever_started;
+}
 
 /* The screen this session was asked for, for when there is no daemon to say */
 void gem_default_screen(int16_t *width, int16_t *height, int16_t *planes)
@@ -152,6 +175,7 @@ int gem_start()
     gfx_open(screen);
 
     started = 1;
+    ever_started = 1;
 
     return 1;
 }
@@ -337,6 +361,11 @@ void gem_forget(void)
     gfx_forget();
     aes_client_forget();
 
+    /* And the console, which has a surface of its own and possibly a window on
+     * the connection that has just been let go of. Here rather than before
+     * gfx_forget so that closing the window is the nothing it should be. */
+    console_forget();
+
     /* And the printer, which is the same argument again: a half drawn page and
      * a half written job belong to the parent, and finishing either would put
      * a second copy of somebody else's document in the queue */
@@ -375,8 +404,13 @@ void gem_present()
     {
         /* Whichever is being drawn into. A dialog's surface starts as a copy
          * of the screen and a menu's as a copy of that, so whichever of them
-         * is on top is the whole picture rather than half of it. */
-        surface_write_ppm(menu ? menu : dialog ? dialog : screen, shot);
+         * is on top is the whole picture rather than half of it - and a
+         * console the program has dropped to is above all three, being what
+         * has taken the screen over for as long as it is there. */
+        struct surface *console = console_showing();
+
+        surface_write_ppm(console ? console
+                          : menu ? menu : dialog ? dialog : screen, shot);
     }
 
     gfx_present();
@@ -425,6 +459,7 @@ void gem_reset()
 
     gem_menu_end();
     gem_dialog_end();
+    console_close();
     gfx_close();
 
     surface_free(screen);

--- a/src/gem_p.h
+++ b/src/gem_p.h
@@ -78,6 +78,17 @@ void gem_default_screen(int16_t *width, int16_t *height, int16_t *planes);
 
 int gem_start();
 
+/*
+ * Whether GEM has been started here or in the process that forked this one,
+ * which outlives gem_forget where gem_start's own answer does not.
+ *
+ * It says what kind of program this is rather than what state GEM is in: one a
+ * person ran from a shell, or one that came out of a GEM application. The
+ * console is what asks - a program of the first kind writes to the shell and
+ * one of the second writes on the screen.
+ */
+int gem_ever_started(void);
+
 /* Lets go of everything a child of fork inherited and should not use: the
  * compositor's connection, the daemon's socket, and the parent's screen */
 void gem_forget(void);

--- a/src/gemdoscon.c
+++ b/src/gemdoscon.c
@@ -1,7 +1,8 @@
 /*
  * TOSEMU - an emulated environment for TOS applications
  * Copyright (C) 2014 Johan Thelin <e8johan@gmail.com>
- * 
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
@@ -22,9 +23,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <termios.h>
-#include <unistd.h>
 
+#include "console.h"
 #include "cpu.h"
 #include "utils.h"
 #include "m68k.h"
@@ -33,19 +33,46 @@
 
 /* Console I/O functions *****************************************************/
 
+/*
+ * All of these go through console.c, which decides whether the console is a
+ * window on the desktop or the terminal the emulator was started from. What is
+ * left here is the shape GEMDOS gives each of them - which of them waits,
+ * which echoes, and what the answer looks like - because that is the part an
+ * application depends on and it is the part that used to be wrong.
+ *
+ * The three that wait are Cconin, Cnecin and Crawcin. That is what an
+ * application expects of them: a program asking for a key with nothing to read
+ * is a program that has stopped until somebody presses one. They used to
+ * answer nought straight away, which is a key that was never pressed.
+ *
+ * The one that does not wait is Crawio with 0xff, which is the whole point of
+ * that call: it asks whether a key is there and answers nought when none is.
+ * A program polling it goes round its loop until one arrives - GenST does
+ * exactly this to wait for the keypress that dismisses its assembler output -
+ * and the loop only ends because something else eventually puts a key in.
+ */
+
 uint32_t GEMDOS_Cconin()
-{   
+{
+    uint32_t key;
+
     FUNC_TRACE_ENTER
-    
-    return getchar() & 0xff; /* TODO no shift key status, scancode */
+
+    key = console_key(1);
+
+    /* Cconin echoes what was typed and Cnecin does not, which is the whole
+     * difference between the two */
+    if (key & 0xff)
+        console_out(key & 0xff);
+
+    return key;
 }
 
 uint32_t GEMDOS_Cnecin()
-{   
+{
     FUNC_TRACE_ENTER
-    
-    /* TODO: turn off not echo. */
-    return getchar() & 0xff; /* TODO no shift key status, scancode */
+
+    return console_key(1);
 }
 
 uint32_t GEMDOS_Cconout()
@@ -54,7 +81,7 @@ uint32_t GEMDOS_Cconout()
         printf("    0x%x '%c'\n", peek_u16(2), peek_u16(2)&0xff);
     }
 
-    putchar(peek_u16(2)&0xff);
+    console_out(peek_u16(2)&0xff);
     return 0;
 }
 
@@ -62,7 +89,7 @@ uint32_t GEMDOS_Cconis()
 {
     FUNC_TRACE_ENTER
 
-    if (console_input_available())
+    if (console_ready())
         return -1;
     else
         return 0;
@@ -84,19 +111,19 @@ uint32_t GEMDOS_Cconws()
     FUNC_TRACE_ENTER_ARGS {
         printf("    0x%x\n", adr);
     }
-    
+
     while((ch=m68k_read_disassembler_8(adr++)))
     {
-        putchar(ch);
+        console_out(ch);
         res++;
     }
-    
+
     return res;
 }
 
 uint32_t GEMDOS_Cconrs()
 {
-    char buf[257]; /* Max len on ST side is 256 */
+    char buf[255]; /* Max len on ST side is 255 */
 
     /* This is a pointer to a LINE struct, i.e.
      *
@@ -109,33 +136,19 @@ uint32_t GEMDOS_Cconrs()
      */
     uint32_t lineptr = peek_u32(2);
 
-    uint8_t maxlen = m68k_read_memory_8(lineptr);
+    int maxlen = m68k_read_memory_8(lineptr);
+    int len;
+    int i;
 
-    fgets(buf, maxlen, stdin);
-    int len = strlen(buf);
-    if (len > 0 && buf[len-1] == '\n')
-    {
-        /* Remove final \n */
-        buf[len-1] = '\0';
-        len --;
-    }
+    if (maxlen > (int)sizeof buf)
+        maxlen = (int)sizeof buf;
 
-    if (len > maxlen)
-    {
-        /* Truncate buffer string if necessary */
-        len = maxlen;
-        buf[len] = '\0';
-    }
+    len = console_line(buf, maxlen);
 
     m68k_write_memory_8(lineptr+1, len);
-    char *ptr = buf;
-    lineptr += 2;
-    do
-    {
-        m68k_write_memory_8(lineptr, *ptr);
-        ptr ++;
-        lineptr ++;
-    } while (*ptr != '\0');
+
+    for (i = 0; i < len; i++)
+        m68k_write_memory_8(lineptr + 2 + i, (uint8_t)buf[i]);
 
     return 0;
 }
@@ -149,34 +162,10 @@ uint32_t GEMDOS_Crawio()
     }
 
     if (w == 0xff)
-    {
-        if (console_input_available())
-        {
-            struct termios t;
-            tcflag_t temp;
+        return console_key(0);
 
-            /* Disable buffering */
-            tcgetattr(STDIN_FILENO, &t);
-            temp = t.c_lflag;
-            t.c_lflag &= ~ICANON;;
-            tcsetattr(STDIN_FILENO, TCSANOW, &t);
-
-            uint32_t res = getchar() & 0xff; /* TODO no shift key status, scancode */
-
-            /* Restore echoing */
-            t.c_lflag = temp ;
-            tcsetattr(STDIN_FILENO, TCSANOW, &t);
-
-            return res;
-        }
-        else
-            return 0;
-    }
-    else
-    {
-        /* Write character to stdout */
-        putchar(w&0xff);
-    }
+    /* Anything else is a character to write */
+    console_out(w & 0xff);
 
     return 0;
 }
@@ -185,25 +174,5 @@ uint32_t GEMDOS_Crawcin()
 {
     /*FUNC_TRACE_ENTER*/
 
-    if (console_input_available())
-    {
-        struct termios t;
-        tcflag_t temp;
-
-        /* Disable buffering and echoing */
-        tcgetattr(STDIN_FILENO, &t);
-        temp = t.c_lflag;
-        t.c_lflag &= ~( ICANON | ECHO );;
-        tcsetattr(STDIN_FILENO, TCSANOW, &t);
-
-        uint32_t res = getchar() & 0xff; /* TODO no shift key status, scancode */
-
-        /* Restore echoing */
-        t.c_lflag = temp;
-        tcsetattr(STDIN_FILENO, TCSANOW, &t);
-
-        return res;
-    }
-    else
-        return 0;
+    return console_key(1);
 }

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -322,14 +322,16 @@ struct window {
 /*
  * Slot 0 is the dialog, because there is one of those at a time. Then the GEM
  * windows, which the AES allows eight of and numbers from one, so their handle
- * is their slot. The menu bar and whichever menu is down get slots of their
- * own after those: the AES does not give them handles, and taking one of the
- * eight would be taking a window an application is entitled to.
+ * is their slot. The menu bar, whichever menu is down and the console get
+ * slots of their own after those: the AES does not give them handles, and
+ * taking one of the eight would be taking a window an application is entitled
+ * to.
  */
 #define DIALOG   (0)
 #define MENUBAR  (9)
 #define MENU     (10)
-#define WINDOWS  (11)
+#define CONSOLE  (11)
+#define WINDOWS  (12)
 
 #endif /* NO_WAYLAND */
 
@@ -598,6 +600,13 @@ static void keys_from_environment(void)
 }
 
 static void clicks_from_environment(void);
+
+int gfx_key_ready(void)
+{
+    keys_from_environment();
+
+    return w.key_count > 0;
+}
 
 int gfx_key_take(uint16_t *key)
 {
@@ -3113,6 +3122,21 @@ static void say_why_there_is_no_window(void)
                "memory\n");
 }
 
+int gfx_possible(void)
+{
+    /*
+     * Not the same question as whether a connection would succeed, and it
+     * cannot be: finding that out means connecting. What it rules out is the
+     * two ways of knowing there is no point - having been told not to, and
+     * there being no session to connect to - which between them are every case
+     * a test or a machine with nobody logged in falls into.
+     */
+    if (setting_flag("TOSEMU_NO_WINDOW"))
+        return 0;
+
+    return getenv("WAYLAND_DISPLAY") != 0;
+}
+
 int gfx_open(struct surface *screen)
 {
     memset(&w, 0, sizeof w);
@@ -3214,7 +3238,14 @@ void gfx_window_open(int16_t handle, const char *title, int16_t x, int16_t y,
 {
     struct window *win;
 
-    if (!gfx_showing() || handle < 1 || handle >= WINDOWS)
+    /*
+     * Up to and including the bar, which opens its window this way as well -
+     * see aesmenu.c, which passes MENUBAR as the handle. The two slots after
+     * it are not opened from here at all: a menu that has dropped down and the
+     * console each have a call of their own, and a handle that reached either
+     * would be a GEM window put where one of those belongs.
+     */
+    if (!gfx_showing() || handle < 1 || handle > MENUBAR)
         return;
 
     if (sw <= 0 || sh <= 0)
@@ -3739,6 +3770,39 @@ void gfx_dialog_open(struct surface *shows, int16_t x, int16_t y,
 void gfx_dialog_close()
 {
     window_destroy(&w.windows[DIALOG]);
+}
+
+/*
+ * The console, which is a window in its own right rather than a dialog of
+ * anybody's.
+ *
+ * It has no parent on purpose. A dialog belongs to the window it interrupts
+ * and is kept above it; a console interrupts nothing - the program that put it
+ * up has stopped being a GEM program for as long as it is there - and the one
+ * thing a person does with it is read it and press a key. So it takes the
+ * desktop's frame, appears in the window list under its own name, and can be
+ * put wherever it suits.
+ *
+ * Opening one that is already open does nothing, because the console asks
+ * whenever it has something to show and a window taken down and put up again
+ * would move on every line of output.
+ */
+void gfx_console_open(struct surface *shows, int16_t sw, int16_t sh)
+{
+    if (!gfx_showing() || !shows || sw <= 0 || sh <= 0)
+        return;
+
+    if (w.windows[CONSOLE].used)
+        return;
+
+    if (!window_create(&w.windows[CONSOLE], "Console", shows, 0, 0, sw, sh,
+                       0, 0))
+        window_destroy(&w.windows[CONSOLE]);
+}
+
+void gfx_console_close(void)
+{
+    window_destroy(&w.windows[CONSOLE]);
 }
 
 int gfx_fd()
@@ -4288,6 +4352,11 @@ void gfx_present()
  * an application can observe.
  */
 
+int gfx_possible(void)
+{
+    return 0;
+}
+
 int gfx_open(struct surface *screen)
 {
     (void)screen;
@@ -4392,6 +4461,15 @@ void gfx_dialog_open(struct surface *shows, int16_t x, int16_t y,
 }
 
 void gfx_dialog_close()
+{
+}
+
+void gfx_console_open(struct surface *shows, int16_t sw, int16_t sh)
+{
+    (void)shows; (void)sw; (void)sh;
+}
+
+void gfx_console_close(void)
 {
 }
 

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -110,6 +110,25 @@ void host_window_resized(int16_t handle, int16_t w, int16_t h);
 void host_window_activated(int16_t handle, int16_t active);
 
 /*
+ * The pointer in the console's window, which GEM is told nothing about.
+ *
+ * A console window is not a GEM window: no application asked for it, none knows
+ * it is there, and the one thing a person does with it besides read it is
+ * select some of it to copy. So the pointer there is answered by console.c and
+ * never reaches the queue the AES takes its clicks off - which it must not,
+ * because that queue is in the screen's coordinates and this is somewhere else
+ * entirely.
+ *
+ * The place is in the console surface's own pixels, and it arrives with the
+ * move rather than with the press - the pointer is always somewhere before it
+ * is pressed, and an enter is a move as much as a motion is. button is 1 for
+ * the left one, 2 for the right and 3 for the middle, which GEM has no use for
+ * and a console does.
+ */
+void host_console_button(int16_t button, int down);
+void host_console_motion(int16_t x, int16_t y);
+
+/*
  * A title bar drawn into a surface of a window's own, for a window that has
  * none of GEM's and is on a desktop that draws none of its own either.
  *
@@ -1197,6 +1216,20 @@ static void pointer_at(struct window *win, wl_fixed_t x, wl_fixed_t y)
     if (w.on_frame)
         return;
 
+    /*
+     * The console's window is somewhere else, and saying where the pointer is
+     * in it would be saying it about the screen. The two surfaces are the same
+     * size and both start at nought, so the numbers would look perfectly
+     * reasonable and land wherever the application happened to have something
+     * clickable.
+     */
+    if (win == &w.windows[CONSOLE])
+    {
+        host_console_motion((int16_t)(w.frame_x / win->scale),
+                            (int16_t)((w.frame_y - top) / win->scale));
+        return;
+    }
+
     w.mouse_x = (int16_t)(win->sx + w.frame_x / win->scale);
     w.mouse_y = (int16_t)(win->sy + (w.frame_y - top) / win->scale);
     w.mouse_known = 1;
@@ -1268,11 +1301,13 @@ static void pt_button(void *data, struct wl_pointer *p, uint32_t serial,
     if (state == WL_POINTER_BUTTON_STATE_PRESSED)
         w.press_serial = serial;
 
-    /* GEM numbers them from the left, and has two */
+    /* GEM numbers them from the left, and has two. The third is here for the
+     * console, which pastes with it the way a terminal does. */
     switch (button)
     {
         case 0x110: bit = 1; break;     /* BTN_LEFT */
         case 0x111: bit = 2; break;     /* BTN_RIGHT */
+        case 0x112: bit = 3; break;     /* BTN_MIDDLE */
         default: return;
     }
 
@@ -1289,11 +1324,23 @@ static void pt_button(void *data, struct wl_pointer *p, uint32_t serial,
      */
     if (w.on_frame && w.pointer_in)
     {
-        if (state == WL_POINTER_BUTTON_STATE_PRESSED)
+        if (state == WL_POINTER_BUTTON_STATE_PRESSED && bit <= 2)
             frame_press(w.pointer_in, bit);
 
         return;
     }
+
+    /* The console's window, which is not a GEM window and whose clicks the
+     * application is told nothing about */
+    if (w.pointer_in == &w.windows[CONSOLE])
+    {
+        host_console_button(bit, state == WL_POINTER_BUTTON_STATE_PRESSED);
+        return;
+    }
+
+    /* And GEM has no third button to be told about */
+    if (bit > 2)
+        return;
 
     /*
      * Queued, and not written into the state as well.

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -49,6 +49,17 @@ struct surface;
 int gfx_open(struct surface *screen);
 void gfx_close(void);
 
+/*
+ * Whether opening one would be worth trying, asked without trying.
+ *
+ * The console has to decide whether it is a screen or a terminal before it has
+ * anything to draw, and it must not build a screen to find out - a program
+ * that only ever prints a line would be paying for a compositor it is not
+ * going to use. This is the same question gfx_open answers by connecting, up
+ * to the point where connecting is the only way to know more.
+ */
+int gfx_possible(void);
+
 /* Lets go of a connection this process inherited by being forked, without
  * tearing down what belongs to the parent */
 void gfx_forget(void);
@@ -167,6 +178,20 @@ void gfx_dialog_open(struct surface *shows, int16_t x, int16_t y,
 void gfx_dialog_close();
 
 /*
+ * And the console, which is a window of its own for the same reason a dialog
+ * is: what it draws would otherwise appear inside every window showing that
+ * part of the screen.
+ *
+ * It belongs to nothing. A console is not a dialog of the application's - a
+ * program that has dropped to it is not a GEM program for as long as it is
+ * there, and the whole of what it can be asked is to press a key - so it is a
+ * window in its own right, with the desktop's frame round it and its own place
+ * in the window list. See console.c.
+ */
+void gfx_console_open(struct surface *shows, int16_t w, int16_t h);
+void gfx_console_close(void);
+
+/*
  * The connection, for the event loop to wait on beside its timer, or -1 when
  * there is no window.
  */
@@ -265,6 +290,10 @@ void gfx_present();
  * other part of the emulator from having to know a window was involved.
  */
 int gfx_key_take(uint16_t *key);
+
+/* Whether one is waiting, without taking it. The console polls this - Cconis
+ * and Bconstat ask whether a key is there and must not swallow it. */
+int gfx_key_ready(void);
 
 /* As of the last change taken off the queue, which is what a wait wants: it
  * considers each change where that change happened */

--- a/src/scrap.c
+++ b/src/scrap.c
@@ -698,6 +698,85 @@ static char *offer_utf8(size_t *length)
     return 0;
 }
 
+/*
+ * Handing something over to the desktop, and to whatever is standing in for
+ * one.
+ *
+ * Two ways of offering the same cut, because a test has no desktop to offer it
+ * to: TOSEMU_SCRAP_OUT names a file to write the text into, which is the half a
+ * test can read back, and the selection itself is what a person gets.
+ *
+ * The picture goes beside the text rather than instead of it, so that the
+ * program pasting picks which it wants. Either may be null.
+ *
+ * Taking the selection can refuse - no compositor, or nothing the person has
+ * done that this program saw, which is the serial a selection has to be taken
+ * with. That is not worth reporting from here: what was cut is still wherever
+ * it was cut from.
+ */
+static void give_to_desktop(const char *utf8, size_t utf8_length,
+                            const void *png, size_t png_length)
+{
+    struct gfx_offer what[2];
+    int n = 0;
+
+    const char *where = setting("TOSEMU_SCRAP_OUT");
+
+    if (utf8 && where && where[0])
+    {
+        FILE *f = fopen(where, "wb");
+
+        if (f)
+        {
+            if (utf8_length)
+                fwrite(utf8, 1, utf8_length, f);
+
+            fclose(f);
+        }
+    }
+
+    if (utf8)
+    {
+        what[n].mimes = text_kinds;
+        what[n].mimes_n = TEXT_KINDS;
+        what[n].bytes = utf8;
+        what[n].length = utf8_length;
+        n++;
+    }
+
+    if (png)
+    {
+        what[n].mimes = image_kinds;
+        what[n].mimes_n = IMAGE_KINDS;
+        what[n].bytes = png;
+        what[n].length = png_length;
+        n++;
+    }
+
+    gfx_selection_give(what, n);
+}
+
+/*
+ * The same, and the other way round, for text that never went near the scrap
+ * directory.
+ *
+ * The console is what wants these. What a person selects in a console window is
+ * not a GEM cut - no application did it and no SCRAP file is written - so it
+ * goes straight to the desktop, and what comes back from the desktop is turned
+ * into keys rather than into a file. They are here rather than in console.c
+ * because this is where the clipboard is spoken to, and because the stand-ins
+ * that let a test arrange one are here as well.
+ */
+void scrap_desktop_give_text(const char *utf8, size_t length)
+{
+    give_to_desktop(utf8, length, 0, 0);
+}
+
+char *scrap_desktop_text(size_t *length)
+{
+    return offer_utf8(length);
+}
+
 void scrap_refresh(void)
 {
     unsigned long long when;
@@ -808,14 +887,10 @@ void scrap_refresh(void)
 static void offer_scrap(void)
 {
     char source[SCRAP_PATH];
-    const char *where;
     char *atari;
     char *utf8 = 0;
     void *png = 0;
     size_t atari_length, utf8_length = 0, png_length = 0;
-    FILE *f;
-
-    where = setting("TOSEMU_SCRAP_OUT");
 
     /*
      * What came from the desktop does not go back to it.
@@ -871,54 +946,7 @@ static void offer_scrap(void)
     if (!utf8 && !png)
         return;
 
-    /* Where a test looks, there being no desktop in one to look at. The text,
-     * because that is the half a test can read back. */
-    if (utf8 && where && where[0])
-    {
-        f = fopen(where, "wb");
-
-        if (f)
-        {
-            if (utf8_length)
-                fwrite(utf8, 1, utf8_length, f);
-
-            fclose(f);
-        }
-    }
-
-    /*
-     * And the desktop itself, with the picture beside the text when there is
-     * one - the same cut said two ways, and the program pasting picks.
-     *
-     * This can refuse: no compositor, or nothing the person has done that this
-     * program saw, which is the serial a selection has to be taken with. A
-     * refusal is not worth reporting - the scrap is still on disk and another
-     * GEM application can still paste it.
-     */
-    {
-        struct gfx_offer what[2];
-        int n = 0;
-
-        if (utf8)
-        {
-            what[n].mimes = text_kinds;
-            what[n].mimes_n = TEXT_KINDS;
-            what[n].bytes = utf8;
-            what[n].length = utf8_length;
-            n++;
-        }
-
-        if (png)
-        {
-            what[n].mimes = image_kinds;
-            what[n].mimes_n = IMAGE_KINDS;
-            what[n].bytes = png;
-            what[n].length = png_length;
-            n++;
-        }
-
-        gfx_selection_give(what, n);
-    }
+    give_to_desktop(utf8, utf8_length, png, png_length);
 
     free(utf8);
     free(png);

--- a/src/scrap.h
+++ b/src/scrap.h
@@ -86,4 +86,23 @@ int scrap_fd(void);
  * was cut to the desktop */
 void scrap_pump(void);
 
+/*
+ * The desktop's clipboard as text, without the scrap directory in the middle.
+ *
+ * The console is what wants these. Text selected in a console window is not a
+ * GEM cut - no application did it, and there is no SCRAP file for one to have
+ * written - so it goes straight to the desktop, and what comes back is turned
+ * into keys rather than into a file.
+ *
+ * Both are UTF-8 with LF between lines, which is what a desktop deals in;
+ * scraptext.h is what turns that into an ST's text and back. Taking the
+ * selection can refuse, for the reasons in gfx.h, and the stand-ins that let a
+ * test arrange a desktop - TOSEMU_SCRAP_IN and TOSEMU_SCRAP_OUT - work here
+ * exactly as they do for a GEM cut.
+ */
+void scrap_desktop_give_text(const char *utf8, size_t length);
+
+/* Allocates; the caller frees. Null when the desktop is offering no text. */
+char *scrap_desktop_text(size_t *length);
+
 #endif /* SCRAP_H */

--- a/src/settings.c
+++ b/src/settings.c
@@ -70,6 +70,19 @@ static const struct {
     { "TOSEMU_KEYS",        "input",   "keys",        0 },
     { "TOSEMU_CLICKS",      "input",   "clicks",      0 },
 
+    /*
+     * Where a program's console output goes and where it reads keys back
+     * from: `screen` for a window of its own with the machine's own font in
+     * it, `terminal` for the one the emulator was started from.
+     *
+     * Unsaid, it is the screen where there is a compositor to show one and the
+     * terminal where there is not, which is right nearly always. Saying it is
+     * for the two cases where it is not: redirecting an assembler's output
+     * into a file on a desktop, and looking at what a console program drew
+     * without a desktop to look at it on.
+     */
+    { "TOSEMU_CONSOLE",     "console", "output",      0 },
+
     { "TOS_BASE_PATH",      "files",   "base",        0 },
 
     /*

--- a/src/utils.c
+++ b/src/utils.c
@@ -53,22 +53,3 @@ uint32_t endianize_32(uint32_t in)
     
     return out;
 }
-
-/* Checks if the console has available input
- * http://stackoverflow.com/questions/717572/how-do-you-do-non-blocking-console-i-o-on-linux-in-c
- */
-int console_input_available()
-{
-    struct timeval tv;
-    fd_set fds;
-
-    tv.tv_sec = 0;
-    tv.tv_usec = 0;
-
-    FD_ZERO(&fds);
-    FD_SET(STDIN_FILENO, &fds);
-
-    select(STDIN_FILENO+1, &fds, NULL, NULL, &tv);
-
-    return (FD_ISSET(0, &fds));
-}

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,7 +29,4 @@ uint16_t endianize_16(uint16_t in);
 /* Changes endianess of a 32-bits long word */
 uint32_t endianize_32(uint32_t in);
 
-/* Checks if the console has available input */
-int console_input_available();
-
 #endif /* UTILS_H */

--- a/src/xbiosscreen.c
+++ b/src/xbiosscreen.c
@@ -43,6 +43,7 @@
 #include <string.h>
 
 #include "tossystem.h"
+#include "console.h"
 #include "cpu.h"
 #include "m68k.h"
 
@@ -59,7 +60,6 @@ static uint16_t palette[PALETTE_ENTRIES];
 static uint32_t palette_rgb[PALETTE_ENTRIES];
 
 static uint32_t video_mode;
-static uint32_t cursor_rate = 10; /* Blinks per second, the TOS default */
 
 void xbios_screen_reset()
 {
@@ -304,16 +304,11 @@ uint32_t XBIOS_Cursconf()
         printf("    rate: %d, attr: %d\n", rate, attr);
     }
 
-    /* There is no cursor to show, hide or blink, but the blink rate can be
-     * asked for as well as set, http://toshyp.atari.org/en/00400a.html */
-    switch (rate)
-    {
-    case 4: /* Set the blink rate */
-        cursor_rate = attr;
-        return XBIOS_E_OK;
-    case 5: /* Report the blink rate */
-        return cursor_rate;
-    default:
-        return XBIOS_E_OK;
-    }
+    /*
+     * This is the console's cursor rather than the screen's, so the console
+     * answers it, http://toshyp.atari.org/en/00400a.html. There is one to show,
+     * hide and blink now: it is the block on the console window, drawn by
+     * inverting the cell it sits on.
+     */
+    return (uint32_t)(uint16_t)console_cursor((int16_t)rate, (int16_t)attr);
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@
 STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal \
           Fopen Fclose Fread Supexec Dcreate Fcreate Fwrite Fdelete Fattrib \
           cmdline Malloc
-CTESTNAME=c-helloworld c-drives c-bios c-xbios c-super c-linea c-mxalloc c-memory c-pexec c-pexchild c-overlay c-gem c-vdi c-gdos c-print c-prnchild c-aesd c-acc c-userdef c-icon c-boxchar c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-scrap c-poll
+CTESTNAME=c-helloworld c-drives c-bios c-xbios c-console c-super c-linea c-mxalloc c-memory c-pexec c-pexchild c-overlay c-gem c-vdi c-gdos c-print c-prnchild c-aesd c-acc c-userdef c-icon c-boxchar c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-scrap c-poll
 
 # The ones that call the AES or the VDI, whose bindings live in their own
 # library rather than in the C one
@@ -174,6 +174,26 @@ check: all
 	# about: an application says something to whoever is debugging it, and
 	# tosemu is what there is.
 	grep -q 'Dbmsg: a message for the debugger' out
+	# Reading the console, with somebody typing at it - which is what the
+	# sleeps and the printfs are. Three of these calls have to be able to
+	# wait and three have to be able not to, and getting either wrong is
+	# invisible until a program that polls for a keypress never comes back.
+	#
+	# The keys arrive a few at a time on purpose. Fed in all at once there
+	# is never anything to wait for, so a call that answered straight away
+	# would answer correctly and the test would pass either way.
+	#
+	# Under a timeout, because the failure this is about is a run that does
+	# not end: a polling call that waited would sit here for ever, and so
+	# would a waiting one with nothing left to arrive.
+	( sleep 0.4; printf 'a'; sleep 0.3; printf 'b'; \
+	  sleep 0.3; printf 'c\rhi\b\bxy\r' ) \
+	  | $(NO_DAEMON) $(NO_PRINTER) $(TOSEMU_FOR_A_WHILE) test-c-console > out; \
+	  ! grep -q '^not ok' out
+	grep -q '^1\.\.13' out
+	# There is no window here, so that was the console on a terminal. What
+	# it draws when it is on a screen instead is bin/vditest's to check: the
+	# surface is not something a program inside the emulator can read back.
 	# Supervisor mode, which is mostly a question about the stack: a 68000
 	# swaps stack pointers when the S bit moves, and a caller that came back
 	# from Super standing somewhere else has lost everything it had put on

--- a/tests/c-console.c
+++ b/tests/c-console.c
@@ -1,0 +1,137 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * Reading the console, which is the half of it a test can arrange.
+ *
+ * Which of these calls waits and which does not is the whole of what is
+ * checked, and it is what used to be wrong: every one of them answered
+ * straight away, so a program that asked for a key got nought - a key nobody
+ * pressed - and one that polled for a key got the end of the input reported as
+ * a character, over and over, for ever. GenST waits for a keypress this way
+ * after it has assembled something, and it is why it never came back.
+ *
+ * The keys are handed over on standard input by the check line that runs this,
+ * and they arrive a little at a time rather than all at once, which is what
+ * makes the waiting checkable at all: a call that answered straight away would
+ * be answering before the key it is meant to have waited for had been typed.
+ * The first three checks each want a key that is not there yet.
+ *
+ * The last four are what happens once the input has run out - which on a
+ * terminal is the end of a pipe and on a real keyboard cannot happen. A call
+ * that does not wait has to answer that nothing is there, and go on answering
+ * it; a run where the polling ones waited instead would not finish at all,
+ * which is what the timeout on the check line is for.
+ *
+ * The reads happen before anything is printed. Cconin echoes what it read and
+ * Cconrs echoes the line, both onto this same standard output, so doing it the
+ * other way round would scatter them through the middle of the results.
+ */
+
+#include <stdio.h>
+#include <mint/osbind.h>
+
+static int n;
+static int fails;
+
+static void check(long got, long want, const char *name)
+{
+    n++;
+    if (got == want)
+        printf("ok %d - %s\n", n, name);
+    else
+    {
+        fails++;
+        printf("not ok %d - %s (got %ld, want %ld)\n", n, name, got, want);
+    }
+}
+
+/* The LINE structure Cconrs is handed: how much room there is, how much was
+ * used, and the characters */
+static struct {
+    unsigned char maxlen;
+    unsigned char actual;
+    char buffer[255];
+} line;
+
+int main(int argc, char **argv)
+{
+    long cooked, uncooked, from_bios;
+    long waiting_now, bios_now, raw_now;
+    long waiting_after, bios_after, raw_after, again_after;
+
+    (void)argc;
+    (void)argv;
+
+    /*
+     * The three that wait, each for a key that has not been typed yet. Any of
+     * them answering without waiting answers with nought, which is a key
+     * nobody pressed.
+     */
+    cooked = Cconin() & 0xff;
+    uncooked = Crawcin() & 0xff;
+    from_bios = Bconin(2) & 0xff;
+
+    /* The rest of the input arrived with that last one, so now there is
+     * something waiting and the two that ask can say so */
+    waiting_now = Cconis();
+    bios_now = Bconstat(2);
+    raw_now = Crawio(0xff) & 0xff;
+
+    /* "hi", two backspaces and "xy", so what is left is what the editing made
+     * of it rather than what was typed */
+    line.maxlen = sizeof line.buffer;
+    Cconrs((char *)&line);
+
+    /* And now there is nothing, and nothing that can ever arrive. The end of
+     * the input is not a key: a console that has run out is a keyboard nobody
+     * is at, which reports that nothing is waiting rather than reporting a
+     * character that was never typed. */
+    waiting_after = Cconis();
+    bios_after = Bconstat(2);
+    raw_after = Crawio(0xff);
+    again_after = Crawio(0xff);
+
+    /* A line of its own, so that what the reads above echoed is not in front
+     * of the first result */
+    printf("\r\n");
+
+    check(cooked, 'a', "Cconin waits for a key that has not been typed yet");
+    check(uncooked, 'b', "and so does Crawcin");
+    check(from_bios, 'c', "and so does Bconin");
+
+    check(waiting_now, -1, "Cconis says a key is waiting when one is");
+    check(bios_now, -1, "and Bconstat agrees");
+    check(raw_now, '\r', "Crawio(0xff) hands over the key that was waiting");
+
+    check(line.actual, 2, "Cconrs reads a line as long as what was left of it");
+    check(line.buffer[0], 'x', "and the first character survived the editing");
+    check(line.buffer[1], 'y', "and so did the second");
+
+    check(waiting_after, 0, "Cconis says nothing waits once the input has ended");
+    check(bios_after, 0, "and Bconstat says the same");
+    check(raw_after, 0, "Crawio(0xff) answers nothing rather than a character");
+    check(again_after, 0, "and answers the same the second time");
+
+    printf("# %d checks, %d failed\n", n, fails);
+    printf("1..%d\n", n);
+
+    return fails;
+}

--- a/tests/c-xbios.c
+++ b/tests/c-xbios.c
@@ -145,10 +145,13 @@ int main(int argc, char **argv)
     check(VsetMode(-1), VERTFLAG, "VsetMode reports the mode that was set");
     VsetMode(previous);
 
-    check(Cursconf(5, 0), 10, "Cursconf reports the default blink rate");
+    /* Thirty vertical blanks between one state and the next, which at sixty
+     * of them a second is the half second TOS blinked at. It is what EmuTOS's
+     * vt52_init sets, and the console here is EmuTOS's. */
+    check(Cursconf(5, 0), 30, "Cursconf reports the default blink rate");
     Cursconf(4, 25);
     check(Cursconf(5, 0), 25, "Cursconf remembers a new blink rate");
-    Cursconf(4, 10);
+    Cursconf(4, 30);
 
     check(Blitmode(-1), 0, "Blitmode reports no blitter");
     check(EgetShift(), 0, "EgetShift reports 0");


### PR DESCRIPTION
This is driven by Devpac 2 that shows the output of the build stages in a console. Earlier, this went to the host console, but could not capture key events properly. Now a TOS-style console is shown.

Copy paste still works using LMB to select and copy and MMB to paste.