### PR TITLE
VDI: an outline face was drawn at a resolution the device did not have

### DIFF
--- a/src/emuvdi/gdosfsm.c
+++ b/src/emuvdi/gdosfsm.c
@@ -51,6 +51,7 @@
 
 #include "emutos.h"
 #include "asm.h"
+#include "biosext.h"
 #include "intmath.h"
 #include "tosvars.h"
 #include "vdi_defs.h"
@@ -193,12 +194,11 @@ static LONG size_from_height(WORD height)
 /* Where the device is, in dots to the inch ***********************************/
 
 /*
- * An ST high screen is 640 by 400 in the space a monitor showed at about
- * seventy two dots to the inch each way, which is why a ten point .FNT for it
- * is thirteen scan lines tall. The medium screen is the same width and half
- * the height, so a character has to be half as tall in pixels to be the same
- * height on the glass - which is exactly what Atari shipped the second set of
- * font files for. Here it is arithmetic instead.
+ * The one a device that says nothing about itself is taken to have.
+ *
+ * Nothing here should reach it: the screen says how large its pixels are
+ * before a workstation is open, and the printer says so as well. It is what
+ * keeps a division from being by nought.
  */
 #define FSM_BASE_DPI (72)
 
@@ -206,31 +206,60 @@ static LONG size_from_height(WORD height)
  * And when what is being drawn on is not the screen at all, what that has
  * instead. Nought while it is the screen, which is nearly always.
  *
- * It exists for the printer. A screen's resolution can be worked out from its
- * shape because there were only ever a handful of shapes and they were all
- * about the same size of glass; a page has the same shape at three hundred
- * dots to the inch as at six hundred, so nothing about the bitmap says how
- * large a point is on it and the device has to say.
+ * It exists for the printer. The page is a bitmap the emulator made, and it
+ * knows exactly how many dots to the inch it made it at - which is a better
+ * number than the one below can recover, a dot of a three hundred dot page
+ * being 84.6 thousandths of a millimetre and a word only able to hold 84.
  */
 static int elsewhere_x, elsewhere_y;
 
+/*
+ * How large a point is, from how large the device says its dots are.
+ *
+ * This is the same number the application works in. A program that lays a
+ * page out in millimetres or in inches - which is every word processor - turns
+ * them into pixels by the dot size the VDI reports for the device, so a
+ * typeface rendered at any other resolution is a typeface whose size does not
+ * mean what the program's own arithmetic says it means. Atari Works draws its
+ * ruler from this exact number, and its lines are as long as the ruler says.
+ *
+ * The values are Atari's own - 278 thousandths of a millimetre for a screen
+ * larger than an ST's, 372 for ST high - and they are what the .FNT files of
+ * the period were drawn against: Atari's ten point screen font is thirteen
+ * scan lines tall, which is ten points at about ninety dots to the inch, not
+ * at seventy two. So the bitmap faces, the device tables and the outlines all
+ * come to the same size when they come from here.
+ */
+static int dpi_of(WORD microns)
+{
+    if (microns <= 0)
+        return FSM_BASE_DPI;
+
+    return (int)((25400 + microns / 2) / microns);
+}
+
 static int device_ydpi(void)
 {
+    WORD width, height;
+
     if (elsewhere_y > 0)
         return elsewhere_y;
 
-    /* Two hundred lines where a high resolution screen has four hundred, in
-     * the same physical space */
-    return (V_REZ_VT < 300) ? FSM_BASE_DPI / 2 : FSM_BASE_DPI;
+    get_pixel_size(&width, &height);
+
+    return dpi_of(height);
 }
 
 static int device_xdpi(void)
 {
+    WORD width, height;
+
     if (elsewhere_x > 0)
         return elsewhere_x;
 
-    /* And three hundred and twenty columns where it has six hundred and forty */
-    return (V_REZ_HZ < 400) ? FSM_BASE_DPI / 2 : FSM_BASE_DPI;
+    get_pixel_size(&width, &height);
+
+    return dpi_of(width);
 }
 
 void gdos_fsm_device_dpi(int xdpi, int ydpi)


### PR DESCRIPTION
A word processor lays a page out in millimetres or in inches and turns them into pixels by the dot size the VDI reports for the device - work_out[3] and work_out[4] of v_opnwk, which is where a printed page's margins and a ruler's tick marks come from. Whatever else that number is, the fonts have to be rendered at it: a typeface drawn at some other resolution is a typeface whose size does not mean what the application's own arithmetic says it means.

Two places here decided it and they disagreed. hostvars.c reports a screen larger than an ST's as 278 thousandths of a millimetre to the dot, which is Atari's own number for one and comes to ninety one dots to the inch. gdosfsm.c rendered every outline face at a flat seventy two, guessed from the shape of the screen. So a point was twenty seven per cent smaller than the machine said it was.

On the screen that is invisible, because both halves of the application's arithmetic use the same wrong conversion: it measures a line, decides it fills the column, and draws it - and the line looks as though it fills the column, because the ruler it is being compared against was drawn with the same conversion. The same document printed is not, the printer's type being rendered at the resolution the printer declares. Atari Works fits about a quarter more text on a line than there is room for, and a fifteen centimetre column comes out nearly twenty centimetres wide and runs off the right of the sheet.

Atari Works is where it shows, and its ruler is the proof: its tick marks are exactly thirty six pixels to the centimetre, which is 25400 over 278, while a twelve point line of its text measured twelve pixels from ascender to descender, which is twelve points at seventy two. It sets its line spacing to sixteen pixels as well - twelve points at ninety one - so the type was visibly too small for the leading it had been given.

The resolution now comes from get_pixel_size, which is where the numbers the application is told come from, so there is one of them rather than two. That is also the resolution the .FNT files of the period were drawn against: Atari's ten point screen font is thirteen scan lines tall, which is ten points at about ninety dots to the inch and not at seventy two, so the bitmap faces and the outlines now come out the same size as each other as well.

The printer keeps saying its own resolution rather than having it worked back out of the dot size it reports. It knows exactly what it made the page at, and a word cannot hold the answer the other way round: a dot of a three hundred dot page is 84.67 thousandths of a millimetre and what fits is 84. What is left of that is eight parts in a thousand, and it leaves the type slightly narrower than the application expects rather than slightly wider, which is the direction that does not overflow a page.

Outline text on the screen is a quarter larger than it was, which is the whole point of the change: it is now the size the machine says it is.