### PR TITLE
AES: a menu opened over a dialog took the dialog's tree away

### DIFF
--- a/src/aesmenu.c
+++ b/src/aesmenu.c
@@ -221,6 +221,16 @@ int aes_menu_shown()
  *
  * Only the arrival counts. Sitting in the bar afterwards is not a reason to
  * start the menu again.
+ *
+ * And not while a dialog is up. An application inside form_do is waiting for
+ * one of its own buttons and for nothing else, so a menu chosen over the top
+ * of a dialog is a message nobody will ever come and read - which is why the
+ * AES takes the menu tree away from the control manager for as long as a form
+ * owns the screen, in fm_own. Here it matters more than that. The bar is
+ * watched by the wait itself, and the wait a dialog is standing in is the
+ * dialog's own, so running the menu from it brings the bar's tree across on
+ * top of the dialog's - and the dialog is left holding a tree that has been
+ * handed back to the allocator. See aestree.c, which has room for one.
  */
 static int was_among_titles;
 
@@ -229,7 +239,8 @@ int aes_menu_arrived(int16_t x, int16_t y)
     int16_t rx, ry, rw, rh;
     int inside;
 
-    if (!bar_shown || bar_running || !gfx_mouse_known())
+    if (!bar_shown || bar_running || emuvdi_form_showing()
+        || !gfx_mouse_known())
     {
         was_among_titles = 0;
         return 0;

--- a/src/emuvdi/bridge.c
+++ b/src/emuvdi/bridge.c
@@ -591,12 +591,33 @@ void emuvdi_menu_active(int16_t *x, int16_t *y, int16_t *w, int16_t *h)
     *h = gl_ctwait.m_gr.g_h;
 }
 
-/* EmuTOS's form library, aes/gemfmlib.c */
+/* EmuTOS's form library, aes/gemfmlib.c, and the count it keeps of the forms
+ * that own the screen */
 WORD fm_do(OBJECT *tree, WORD start);
+extern WORD ml_ocnt;
 
 int16_t emuvdi_form_do(void *tree, int16_t start)
 {
     return fm_do(tree, start);
+}
+
+/*
+ * Whether a dialog is up, which is that count being anything but nought.
+ *
+ * EmuTOS answers the same question with the same word and does the same thing
+ * with the answer: fm_own takes the menu tree away from the control manager
+ * while a form owns the screen and gives it back afterwards, so that no menu
+ * can be opened over a dialog. There the bar is watched by a process of the
+ * AES's own and a tree it has not got is the whole of the lock; here it is
+ * watched by the wait, so the question has to be asked out loud.
+ *
+ * A form_do inside a form_do counts once, which is why this is a count and not
+ * a flag - the file selector puts an alert up when it cannot read a directory,
+ * and the selector is still there behind it.
+ */
+int16_t emuvdi_form_showing(void)
+{
+    return ml_ocnt > 0;
 }
 
 /* EmuTOS's object library, aes/gemoblib.c */

--- a/src/emuvdi/emuvdi.h
+++ b/src/emuvdi/emuvdi.h
@@ -290,6 +290,16 @@ void emuvdi_iconblk_set(void *blk, void *mask, void *data, char *text,
 int16_t emuvdi_form_do(void *tree, int16_t start);
 
 /*
+ * Whether a dialog has the screen, which is the AES's own count of how many
+ * forms are being run: form_do puts it up on the way in and takes it down on
+ * the way out, and an alert and the file selector are both a form_do.
+ *
+ * It is what says a modal dialog is up, and the AES uses it for that itself -
+ * see the note above aes_menu_arrived, which is the one thing here that asks.
+ */
+int16_t emuvdi_form_showing(void);
+
+/*
  * Puts a menu bar up along the top of the screen, or takes it away. The tree
  * is one aes_tree_in built, and its first two entries are the bar itself and
  * the row of titles along it.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,13 +19,13 @@
 STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal \
           Fopen Fclose Fread Supexec Dcreate Fcreate Fwrite Fdelete Fattrib \
           cmdline Malloc
-CTESTNAME=c-helloworld c-drives c-bios c-xbios c-console c-super c-linea c-mxalloc c-memory c-pexec c-pexchild c-overlay c-gem c-vdi c-gdos c-print c-prnchild c-aesd c-acc c-userdef c-icon c-boxchar c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-scrap c-poll c-keyboard
+CTESTNAME=c-helloworld c-drives c-bios c-xbios c-console c-super c-linea c-mxalloc c-memory c-pexec c-pexchild c-overlay c-gem c-vdi c-gdos c-print c-prnchild c-aesd c-acc c-userdef c-icon c-boxchar c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-scrap c-poll c-keyboard c-modal
 
 # The ones that call the AES or the VDI, whose bindings live in their own
 # library rather than in the C one
 GEMTESTNAME=c-gem c-vdi c-gdos c-print c-prnchild c-aesd c-scrap c-acc c-userdef c-icon c-boxchar \
             c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-poll \
-            c-keyboard
+            c-keyboard c-modal
 
 # Where the sources are, found through the makefile that was read rather than
 # from the directory make happens to be standing in, since it is standing in
@@ -436,6 +436,18 @@ check: all
 	# what these run on.
 	TOSEMU_CLICKS='@32,8 @96,8 @100,27 100,27' $(TOSEMU) test-c-menu > out; \
 	  ! grep -q '^not ok' out
+	grep -q '^1\.\.' out
+	# The menu bar while a dialog is up, which is a menu bar nobody may
+	# touch. The pointer walks into the bar and picks the first entry of the
+	# File menu while form_do has the screen - the same three moves and a
+	# press as above - and then presses the dialog's own button. Nothing may
+	# have been chosen from the menu, and the dialog has to have come out of
+	# it unharmed: a bar that answers while a dialog is up brings its own
+	# tree across on top of the dialog's, and form_do then reads memory that
+	# has been handed back. Which is a crash, so the count line matters more
+	# here than the checks before it.
+	TOSEMU_CLICKS='@32,8 @96,8 @100,27 100,27 120,152 120,152' \
+	  $(TOSEMU) test-c-modal > out; ! grep -q '^not ok' out
 	grep -q '^1\.\.' out
 	# Asking where the mouse is rather than waiting for it, which is what an
 	# application tracking a slider does. The pointer is moved twice and

--- a/tests/c-modal.c
+++ b/tests/c-modal.c
@@ -1,0 +1,276 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * The menu bar while a dialog is up, which is a menu bar nobody may touch.
+ *
+ * A modal dialog is the application saying it will do nothing else until this
+ * is answered, and the AES held it to that: form_do waits for the keyboard and
+ * the mouse and for nothing else, so a menu chosen over the top of one would
+ * be a message the application cannot come and read. On an ST the menu was run
+ * by a process of the AES's own, which had its own stack and its own copy of
+ * everything, and the message waited in the queue.
+ *
+ * Here there is one of everything. The bar and the dialog are both trees
+ * brought across from the machine's memory into the AES's, one at a time, so
+ * running the menu over a dialog takes the dialog's own copy away from the
+ * form_do that is standing in it - and what it does next is read a tree that
+ * has been handed back to the allocator. That is a crash rather than a wrong
+ * answer, which is why this test's own count line is half of what it checks.
+ *
+ * So the pointer is walked into the bar and a menu chosen from while form_do
+ * has the screen, and the dialog has to come out of it unharmed: the button
+ * that was pressed answered form_do, the press came back in the application's
+ * own tree, and nothing was chosen from a menu that should not have opened.
+ *
+ * The pointer is moved and pressed by TOSEMU_CLICKS, there being nobody here
+ * to do it, and the coordinates are the high resolution screen's - see the
+ * check line in the Makefile.
+ */
+
+#include <stdio.h>
+#include <gem.h>
+
+/* Where everything in a menu tree sits. The AES walks it by position - see
+ * demos/menu.c, which says the whole shape out loud. */
+enum {
+    THESCREEN,
+    THEBAR,
+    THEACTIVE,
+
+    T_DESK, T_FILE,
+
+    THEMENUS,
+
+    M_DESK,
+    I_ABOUT,
+    I_SEP,
+    I_ACC1, I_ACC2, I_ACC3,
+    I_ACC4, I_ACC5, I_ACC6,
+
+    M_FILE,
+    I_OPEN,
+    I_SAVE,
+    I_QUIT,
+
+    NUM_MENU_OBJECTS
+};
+
+/* And the dialog, which is a box with a line of words and a button in it */
+enum {
+    D_BOX,
+    D_WORDS,
+    D_OK,
+
+    NUM_DIALOG_OBJECTS
+};
+
+static OBJECT menu[NUM_MENU_OBJECTS];
+static OBJECT dialog[NUM_DIALOG_OBJECTS];
+
+/* A black border, black text, drawn over whatever is beneath it, filled solid
+ * white, with a one pixel border drawn inside the edge */
+#define WHITE_BOX  (0x00ff11f0L)
+
+/* The same, with the two pixels of border a dialog is drawn with */
+#define DIALOG_BOX (0x00021100L)
+
+static int n;
+
+static void check(long got, long want, const char *name)
+{
+    n++;
+    if (got == want)
+        printf("ok %d - %s\n", n, name);
+    else
+        printf("not ok %d - %s (got %ld, want %ld)\n", n, name, got, want);
+}
+
+static void object(OBJECT *tree, short which, short next, short head,
+                   short tail, short type, short flags, long spec,
+                   short x, short y, short w, short h)
+{
+    OBJECT *o = &tree[which];
+
+    o->ob_next = next; o->ob_head = head; o->ob_tail = tail;
+    o->ob_type = type; o->ob_flags = flags; o->ob_state = 0;
+    o->ob_spec.index = spec;
+    o->ob_x = x; o->ob_y = y; o->ob_width = w; o->ob_height = h;
+}
+
+static void build_menu(short wchar, short hchar, short hbox, short width)
+{
+    short title_w = 8 * wchar;      /* "  Desk  " and "  File  " */
+    short item_w = 14 * wchar;
+    short i;
+
+    object(menu, THESCREEN, NIL, THEBAR, THEMENUS, G_IBOX, 0, 0L,
+           0, 0, width, 200);
+
+    object(menu, THEBAR, THEMENUS, THEACTIVE, THEACTIVE, G_BOX, 0, 0x00001100L,
+           0, 0, width, hbox);
+    object(menu, THEACTIVE, THEBAR, T_DESK, T_FILE, G_IBOX, 0, 0L,
+           0, 0, 2 * title_w, hbox);
+
+    object(menu, T_DESK, T_FILE, NIL, NIL, G_TITLE, 0, (long)"  Desk  ",
+           0, 0, title_w, hbox);
+    object(menu, T_FILE, THEACTIVE, NIL, NIL, G_TITLE, 0, (long)"  File  ",
+           title_w, 0, title_w, hbox);
+
+    object(menu, THEMENUS, THESCREEN, M_DESK, M_FILE, G_IBOX, 0, 0L,
+           0, 0, width, 200);
+
+    object(menu, M_DESK, M_FILE, I_ABOUT, I_ACC6, G_BOX, 0, WHITE_BOX,
+           0, hbox, item_w, 8 * hchar);
+
+    object(menu, I_ABOUT, I_SEP, NIL, NIL, G_STRING, 0, (long)"  About...    ",
+           0, 0, item_w, hchar);
+    object(menu, I_SEP, I_ACC1, NIL, NIL, G_STRING, 0, (long)"--------------",
+           0, hchar, item_w, hchar);
+
+    for (i = 0; i < 6; i++)
+        object(menu, I_ACC1 + i, (i == 5) ? M_DESK : I_ACC1 + i + 1, NIL, NIL,
+               G_STRING, 0, (long)"              ",
+               0, (i + 2) * hchar, item_w, hchar);
+
+    object(menu, M_FILE, THEMENUS, I_OPEN, I_QUIT, G_BOX, 0, WHITE_BOX,
+           title_w, hbox, item_w, 3 * hchar);
+    object(menu, I_OPEN, I_SAVE, NIL, NIL, G_STRING, 0, (long)"  Open...     ",
+           0, 0, item_w, hchar);
+    object(menu, I_SAVE, I_QUIT, NIL, NIL, G_STRING, 0, (long)"  Save...     ",
+           0, hchar, item_w, hchar);
+    object(menu, I_QUIT, M_FILE, NIL, NIL, G_STRING, OF_LASTOB,
+           (long)"  Quit        ", 0, 2 * hchar, item_w, hchar);
+
+    menu[I_SEP].ob_state = OS_DISABLED;
+}
+
+/*
+ * The dialog, well below the bar and the menus that drop out of it.
+ *
+ * Where it is matters, because the same clicks that work the menu have to miss
+ * the dialog on the way: a press that landed on one of its objects would end
+ * form_do early and the menu would never have been opened over anything.
+ */
+static void build_dialog(short wchar, short hchar)
+{
+    object(dialog, D_BOX, NIL, D_WORDS, D_OK, G_BOX, 0, DIALOG_BOX,
+           10 * wchar, 6 * hchar, 24 * wchar, 5 * hchar);
+
+    object(dialog, D_WORDS, D_OK, NIL, NIL, G_STRING, 0,
+           (long)"Answer this first", 2 * wchar, hchar, 20 * wchar, hchar);
+
+    /* EXIT is what makes a button end the dialog, and a button that ended one
+     * is left selected - which is the state this test reads back */
+    object(dialog, D_OK, D_BOX, NIL, NIL, G_BUTTON,
+           OF_SELECTABLE|OF_DEFAULT|OF_EXIT|OF_LASTOB, (long)"OK",
+           4 * wchar, 3 * hchar, 6 * wchar, hchar);
+}
+
+int main(int argc, char **argv)
+{
+    short wchar, hchar, wbox, hbox;
+    short work_in[11], work_out[57];
+    short handle, message[8];
+    short wide, high;
+    short mx, my, buttons, kstate, key, clicks;
+    short happened, pressed;
+    short i;
+
+    if (appl_init() < 0)
+    {
+        printf("Bail out! - no AES to talk to\n");
+        return 1;
+    }
+
+    handle = graf_handle(&wchar, &hchar, &wbox, &hbox);
+    for (i = 0; i < 10; i++)
+        work_in[i] = 1;
+    work_in[10] = 2;
+    v_opnvwk(work_in, &handle, work_out);
+
+    wide = work_out[0] + 1;
+    high = work_out[1] + 1;
+
+    build_menu(wchar, hchar, hbox, wide);
+    build_dialog(wchar, hchar);
+
+    /* Where the clicks have to land, said out loud: they are worked out here
+     * and written down in the Makefile, and a screen with another character
+     * size on it would want them somewhere else */
+    printf("# the File menu drops down at %d,%d and OK is at %d,%d\n",
+           8 * wchar, hbox,
+           dialog[D_BOX].ob_x + dialog[D_OK].ob_x + wchar,
+           dialog[D_BOX].ob_y + dialog[D_OK].ob_y + hchar / 2);
+
+    if (!menu_bar(menu, 1))
+    {
+        printf("Bail out! - the AES would not take the menu\n");
+        return 1;
+    }
+
+    /*
+     * And the dialog, which reserves the screen it sits on the way every GEM
+     * dialog does. That is what says a dialog is up: the AES is told before
+     * anything is drawn and told again when it is finished with.
+     */
+    form_dial(FMD_START, 0, 0, 0, 0,
+              dialog[D_BOX].ob_x, dialog[D_BOX].ob_y,
+              dialog[D_BOX].ob_width, dialog[D_BOX].ob_height);
+
+    objc_draw(dialog, D_BOX, 8, dialog[D_BOX].ob_x, dialog[D_BOX].ob_y,
+              dialog[D_BOX].ob_width, dialog[D_BOX].ob_height);
+
+    pressed = form_do(dialog, 0);
+
+    check(pressed, D_OK, "the dialog ended on the button that was pressed");
+    check(dialog[D_OK].ob_state & OS_SELECTED, OS_SELECTED,
+          "and the press came back in the application's own tree");
+
+    form_dial(FMD_FINISH, 0, 0, 0, 0,
+              dialog[D_BOX].ob_x, dialog[D_BOX].ob_y,
+              dialog[D_BOX].ob_width, dialog[D_BOX].ob_height);
+
+    /*
+     * And whether a menu was chosen from while all that was going on, which is
+     * a message sitting in the queue - form_do does not ask for messages, so
+     * one chosen over the dialog would be waiting here rather than lost.
+     *
+     * A timer to give up after, because the answer this wants is silence and a
+     * wait for a message that is not coming would otherwise be the whole of
+     * the test.
+     */
+    happened = evnt_multi(MU_MESAG|MU_TIMER, 0, 0, 0,
+                          0, 0, 0, 0, 0,
+                          0, 0, 0, 0, 0,
+                          message, 250L,
+                          &mx, &my, &buttons, &kstate, &key, &clicks);
+
+    check(happened, MU_TIMER, "and no menu was opened over the top of it");
+
+    printf("1..%d\n", n);
+
+    menu_bar(0L, 0);
+
+    v_clsvwk(handle);
+    appl_exit();
+
+    return 0;
+}


### PR DESCRIPTION
Choosing something from the menu bar while a dialog was up crashed the emulator. The pointer arriving among the titles was enough to start the menu; the dialog standing behind it was then holding memory that had been handed back, and the next thing form_do did with that memory - ob_find, on the press that followed - read it.

The bar is watched by the wait, in aesevnt.c, and that wait serves two callers. One is the application asking for an event of its own, where watching the bar is exactly right: the menu belongs to the AES rather than to the application, so it is watched whatever the application asked for. The other is the AES waiting inside a call of its own. form_do is a loop over the same waiting, and so are the alert and the file selector, both of which are a form_do. Running the menu from the second kind brings the bar's tree across on top of the dialog's, and there is room for one: aes_tree_in begins by letting go of whatever was already there.

EmuTOS has the same rule and keeps it in fm_own, which takes the menu tree away from the control manager for as long as a form owns the screen and gives it back afterwards - so there is no bar to watch and nothing to choose from. There the lock is a pointer the control manager has not got, the control manager being a process of the AES's own; here the bar is watched by the wait, so the question has to be asked out loud. It is asked of ml_ocnt, which is fm_own's own count of the forms that own the screen. A count rather than a flag, because the file selector puts an alert up over itself when it cannot read a directory.

Nobody had noticed because a dialog is usually answered rather than left standing, and the bar is something a person only reaches for once a dialog has been up long enough to be forgotten about. On an ST it did no harm either: the menu ran in a process of its own, with its own stack and its own copy of everything, and what it chose waited in a queue form_do was not reading from.

tests/c-modal.c puts a bar and a modal dialog up together, walks the pointer into the bar while form_do has the screen and picks the first entry of the File menu the way test-c-menu does, and then presses the dialog's own button. What it checks is that form_do answered with that button, that the press came back in the application's own tree - which is what does not happen once the copy has been taken away - and that nothing was chosen from a menu that should not have opened. The count line at the end matters more than any of the three, this being a crash rather than a wrong answer.