### PR TITLE
Enable keyboard shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SOURCEFILES = main.c gemdos.c gemdosmem.c gemdoscon.c console.c gemdosfile.c gem
               xbios.c xbiosscreen.c xbiossys.c xbiosdev.c bios.c \
               gem.c aesclient.c aes.c aesappl.c aesevnt.c aesgraf.c aeswind.c aesmenu.c aesframe.c aesfsel.c aesobjc.c aesrsrc.c aesscrp.c aesshel.c aestree.c vdi.c surface.c \
               gfx.c screen.c settings.c scrap.c scraptext.c scrapimg.c \
+              keyboard.c \
               fontface.c printer.c \
               linea.c \
               tossystem.c utils.c memory.c cpu.c
@@ -198,7 +199,7 @@ all: $(BIN)/tosemu $(BIN)/tosaesd
 
 .PHONY: all tests check devpac-tests devpac-check lattice-tests lattice-check \
         emuvdi-check gdos-check screen-check settings-check scrap-check icon-check \
-        print-check \
+        print-check keyboard-check \
         demos clean
 
 # A checkout without --recurse-submodules leaves the submodule an empty
@@ -423,6 +424,18 @@ $(BIN)/settingstest: $(SRC)/settingstest.c $(OBJ)/settings.o
 settings-check: $(BIN)/settingstest
 	./$(BIN)/settingstest
 
+# What a modified key press becomes, checked without a keyboard to hold a
+# modifier down on. Host built for the same reason as the two above: a
+# compositor is the only thing that reports a modifier and it is not something a
+# test can arrange, so the rules are a function of their own and the words are
+# handed to it directly.
+$(BIN)/keyboardtest: $(SRC)/keyboardtest.c $(OBJ)/keyboard.o $(OBJ)/scraptext.o
+	@mkdir -p $(BIN)
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
+
+keyboard-check: $(BIN)/keyboardtest
+	./$(BIN)/keyboardtest
+
 # The picture on the windows, checked without a task bar to put it in. Host
 # built for the same reason as the two above, and it checks the one half of
 # this that can be checked: which picture came out of somebody else's resource
@@ -551,7 +564,7 @@ $(BIN)/m64kmake: $(SRC)/Musashi/m68kmake.c
 	$(CC) $(CFLAGS) -no-pie $< -o $@
 
 check: $(BIN)/tosemu $(BIN)/tosaesd screen-check settings-check scrap-check \
-       icon-check gdos-check print-check
+       icon-check gdos-check print-check keyboard-check
 	$(MAKE) -C tests check
 
 devpac-check: $(BIN)/tosemu

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ WAYLANDLIBS =
 WAYLANDONLYLIBS =
 endif
 
-EMUVDIFILES = emuvdi/hostvars.c emuvdi/hostfs.c emuvdi/fonts.c emuvdi/gdosfnt.c emuvdi/gdosfsm.c emuvdi/prndev.c emuvdi/textblit.c emuvdi/conout.c emuvdi/bridge.c \
+EMUVDIFILES = emuvdi/hostvars.c emuvdi/hostfs.c emuvdi/fonts.c emuvdi/keytables.c emuvdi/gdosfnt.c emuvdi/gdosfsm.c emuvdi/prndev.c emuvdi/textblit.c emuvdi/conout.c emuvdi/bridge.c \
               emuvdi/gsx2.c emuvdi/gemoblib.c emuvdi/gemobjop.c emuvdi/gemfmalt.c emuvdi/gemmnlib.c emuvdi/vdi_raster.c emuvdi/aeskernel.c \
               emuvdi/strings.c
 

--- a/README.md
+++ b/README.md
@@ -466,6 +466,44 @@ happened, so nothing is written to the scrap directory and no other GEM program
 can paste it; it goes straight to the desktop, where a person put it.
 
 
+The keyboard
+============
+
+A keypress reaches a GEM application as one word: which key, and what it typed.
+Both halves are the machine's rather than the desktop's. The key is a place on
+an ST keyboard, which is a number a Linux keyboard happens to agree with for
+the whole main block, and the character is a byte of the Atari character set,
+which is what the desktop's Unicode is turned into.
+
+The layout is the desktop's and it decides what gets typed: a Swedish keyboard
+types the ST's byte for a with a ring, and a character the ST has no byte for
+types nothing rather than a question mark.
+
+What it does not decide is the shortcuts. A menu shortcut on Alternate and a
+letter arrives as the key with nothing typed, which is how TOS said a key had
+been pressed rather than typed, and an application gets the letter back by
+looking the key up in the keyboard table - `Keytbl`, which hands out what each
+key of the machine types unshifted, shifted and with caps lock down. So that
+table is built from the layout on the desktop, and the letter printed on the
+key somebody pressed is the letter the application matches against its own
+menu. It works on any layout for that reason rather than by accident.
+
+Where there is no desktop to ask - a test, a terminal, a machine with nobody
+logged in - the table is the American one an ST was sold with. `-v` says which
+of the two a run is using.
+
+The rest of what a modifier does is TOS's and is done as TOS did it: Shift and
+a function key is F11 to F20 rather than F1 to F10 with a shift held, Control
+and the left, right or Home key is a key of its own, Control and a character is
+that character with its top three bits taken off, and Shift and Tab is a tab -
+which is what a dialog reads to go back a field rather than on to the next one.
+
+An ST's Undo and Help have nowhere to be on a modern keyboard, so Print Screen
+and Scroll Lock stand in for them. A compositor may well want Print Screen for
+itself, in which case Undo has to be reached some other way; that is the
+compositor's to decide.
+
+
 Fonts
 =====
 

--- a/TODO
+++ b/TODO
@@ -85,6 +85,30 @@
   and have to be composed from a single surface rather than shown side by
   side - which is the same piece of work as the surface router, and neither is
   needed until then.
+- A keyboard table an application installs through Keytbl changes what the next
+  application to ask is told and nothing else, because nothing in tosemu reads
+  the tables: what a key types is what the desktop says it types. Handing out a
+  table is what applications actually want it for - a menu shortcut on
+  Alternate and a letter arrives as a key with no character, and the table is
+  how the letter is got back - so the half that matters works. What does not is
+  a program that installs a layout of its own and expects to type with it,
+  which was how a person changed keyboard on an ST. Closing it means keyboard.c
+  reading the installed table rather than the codepoint, and then the layout on
+  the desktop stops deciding what gets typed, which is a decision rather than a
+  detail.
+- The keypad an ST had is unreachable, and the cursor keys are the reason. An
+  ST puts its cursor block where a PC keyboard puts its keypad, and it is the
+  cursor keys a GEM application waits for, so a PC's keypad is read as the
+  cursor block and the ST's own keypad - scan codes 0x67 to 0x72, which some
+  applications use for numbers - has nothing pointing at it. What would close
+  it is a setting: one keyboard cannot be both, and which of the two somebody
+  wants depends on the application in front of them.
+- The alternate translation tables in a KEYTAB are not handed out, only the
+  three TOS 1.0 had. They arrived with the _AKP cookie, which tosemu has no
+  cookie jar to declare, so an application has no way to look for them and no
+  reason to read past the three - but the structure it is given is three
+  pointers long, and an application that reads a fourth reads whatever is
+  reserved after it.
 - A GEM application is told what the desktop has on its clipboard only while
   one of its windows has the keyboard, which is Wayland's rule rather than
   anything tosemu chooses: a client with no focused surface is sent no

--- a/src/emuvdi/emuvdi.h
+++ b/src/emuvdi/emuvdi.h
@@ -412,4 +412,17 @@ int emuvdi_gdos_installed(void);
  */
 int emuvdi_gdos_scalable(void);
 
+/*
+ * The keyboard table an ST keyboard had: what each of its keys types
+ * unshifted, shifted, and with caps lock down, a hundred and twenty eight
+ * bytes to a table.
+ *
+ * It is what an application reads through XBIOS Keytbl, and it is EmuTOS's -
+ * see emuvdi/keytables.c, which says which set is taken and why. What is
+ * handed out is built from the layout the person is typing on where there is
+ * one to ask about; this is the answer when there is not.
+ */
+void emuvdi_keyboard_tables(const uint8_t **norm, const uint8_t **shift,
+                            const uint8_t **caps);
+
 #endif /* EMUVDI_H */

--- a/src/emuvdi/keytables.c
+++ b/src/emuvdi/keytables.c
@@ -1,0 +1,64 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * The keyboard table an ST keyboard had.
+ *
+ * Three arrays of a hundred and twenty eight bytes, one for each key of the
+ * machine, saying what that key types: unshifted, shifted, and with caps lock
+ * down. An application reads them through XBIOS Keytbl, and what it usually
+ * wants is the question the other way round - which letter is on the key that
+ * arrived - because a menu shortcut is a key rather than a character.
+ *
+ * The tables are EmuTOS's, taken directly rather than through bios/font.c's
+ * neighbour country.c, which picks a set for the country a machine was sold in.
+ * That is the same trade fonts.c makes and for the same reason: the choice is a
+ * question about a machine and answering it would drag in the whole
+ * localisation apparatus. The American set is the one taken because it is the
+ * one the keys of a modern keyboard are arranged in, near enough, on every
+ * layout that has letters where QWERTY has them.
+ *
+ * It is a fallback rather than the answer. What tosemu hands an application is
+ * built from the layout the person is actually typing on when there is a
+ * desktop to ask - see gfx_keyboard_table - so that the letter printed on the
+ * key is the letter the application is told about. This is what there is to
+ * hand over when there is nobody to ask, which is a test, a terminal, or a
+ * machine with nobody logged in.
+ */
+
+#include "emutos.h"
+#include "asm.h"
+#include "intmath.h"
+#include "tosvars.h"
+#include "vdi_defs.h"
+#include "lineavars.h"
+#include "ikbd.h"
+
+#include <stdint.h>
+
+#include "keyb_us.h"
+
+void emuvdi_keyboard_tables(const uint8_t **norm, const uint8_t **shift,
+                            const uint8_t **caps)
+{
+    *norm = keytbl_us.norm;
+    *shift = keytbl_us.shft;
+    *caps = keytbl_us.caps;
+}

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -806,6 +806,117 @@ uint16_t gfx_kstate()
 #endif
 }
 
+/* Where the identity between a scan code and a key number holds, which is
+ * everything below the block an ST puts its cursor keys in */
+#define KEYBOARD_FIRST_KEY (0x01)
+#define KEYBOARD_LAST_KEY  (0x46)
+
+#ifndef NO_WAYLAND
+/* Which bit a modifier is, or none at all: a keymap that has not got the
+ * modifier answers with an index that is not one, and shifting by it is not
+ * something C has an answer for */
+static xkb_mod_mask_t modifier_bit(const char *name)
+{
+    xkb_mod_index_t which = xkb_keymap_mod_get_index(w.keymap, name);
+
+    if (which == XKB_MOD_INVALID)
+        return 0;
+
+    return (xkb_mod_mask_t)1 << which;
+}
+#endif
+
+/*
+ * The keyboard table, as the keyboard the person is actually typing on.
+ *
+ * An ST kept three arrays of what each of its keys types - unshifted, shifted,
+ * and with caps lock down - and an application reads them to ask the question
+ * the other way round: which letter is on the key that arrived. A menu shortcut
+ * is a key rather than a character, so that is the only way to get the letter
+ * back, and an answer taken from some other keyboard is an answer about a key
+ * the person did not press.
+ *
+ * Which is why it is built here rather than carried. The scan code of a key and
+ * its number on a Linux keyboard are the same number for the whole main block -
+ * that is the identity kb_key already relies on the other way round - so each
+ * one can simply be asked about: what does this key type with nothing held,
+ * with shift, with caps lock. The answer is Unicode, being the desktop's, and
+ * scrap_text_key knows the ST's spelling of it.
+ *
+ * Only the block where the identity holds is asked about, which stops before
+ * the cursor keys: an ST has those where a PC has its keypad, so asking where
+ * they are would put a seven on the Home key. Anything else, including every
+ * key the desktop says types nothing, is left as the caller had it - the table
+ * that comes with the machine, which is what those entries are already right
+ * about.
+ *
+ * Answers 0 when there is nobody to ask, which is a run with no window: the
+ * caller then has the table it started with and an application still gets one.
+ */
+int gfx_keyboard_table(uint8_t *norm, uint8_t *shift, uint8_t *caps)
+{
+#ifdef NO_WAYLAND
+    (void)norm; (void)shift; (void)caps;
+
+    return 0;
+#else
+    /* The three tables, and what has to be down for each of them. Caps lock is
+     * locked rather than held, which is what makes the desktop answer with a
+     * capital. */
+    struct {
+        uint8_t *into;
+        xkb_mod_mask_t held;
+        xkb_mod_mask_t locked;
+    } table[3];
+
+    struct xkb_state *asking;
+    uint16_t code;
+    int i;
+
+    if (!w.keymap)
+        return 0;
+
+    asking = xkb_state_new(w.keymap);
+    if (!asking)
+        return 0;
+
+    table[0].into = norm;
+    table[0].held = 0;
+    table[0].locked = 0;
+    table[1].into = shift;
+    table[1].held = modifier_bit(XKB_MOD_NAME_SHIFT);
+    table[1].locked = 0;
+    table[2].into = caps;
+    table[2].held = 0;
+    table[2].locked = modifier_bit(XKB_MOD_NAME_CAPS);
+
+    for (i = 0; i < 3; i++)
+    {
+        xkb_state_update_mask(asking, table[i].held, 0, table[i].locked,
+                              0, 0, 0);
+
+        for (code = KEYBOARD_FIRST_KEY; code <= KEYBOARD_LAST_KEY; code++)
+        {
+            /* Wayland counts keys from a different place than xkb does, the
+             * same way round as in kb_key */
+            uint32_t cp = xkb_state_key_get_utf32(asking, code + 8);
+            int typed;
+
+            if (!cp)
+                continue;
+
+            typed = scrap_text_key(cp);
+            if (typed > 0)
+                table[i].into[code] = (uint8_t)typed;
+        }
+    }
+
+    xkb_state_unref(asking);
+
+    return 1;
+#endif
+}
+
 /*
  * Clicks asked for on the command line, for when nobody is going to click.
  *
@@ -3234,6 +3345,15 @@ int gfx_open(struct surface *screen)
         return 0;
     }
 
+    /*
+     * Somewhere to compile a keyboard layout, before anything is asked of the
+     * compositor rather than after. The context needs nothing from Wayland,
+     * and a layout arriving before there is one to compile it with is a layout
+     * thrown away - which used to be the ordinary case rather than a race,
+     * because this was made once the asking below had finished.
+     */
+    w.xkb = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+
     w.registry = wl_display_get_registry(w.display);
     wl_registry_add_listener(w.registry, &registry_listener, 0);
     wl_display_roundtrip(w.display);
@@ -3259,12 +3379,30 @@ int gfx_open(struct surface *screen)
     if (w.icon_manager)
         wl_display_roundtrip(w.display);
 
+    /*
+     * And as many more as it takes for the keyboard, which arrives in two
+     * steps: the seat says it has one, and only then does the compositor send
+     * the layout somebody is typing on.
+     *
+     * Waiting for it here rather than letting it turn up is what makes the
+     * keyboard table right. An application asks for that table as it starts -
+     * it is where the letters of its own menu shortcuts come from, see XBIOS
+     * Keytbl - and one built before the layout arrived is the table of the
+     * machine this pretends to be rather than of the keyboard in front of the
+     * person. Bounded, because a compositor that is never going to answer must
+     * not be waited on for ever.
+     */
+    {
+        int turns;
+
+        for (turns = 0; turns < 3 && w.seat && !w.keymap; turns++)
+            wl_display_roundtrip(w.display);
+    }
+
     /* Before any window is opened, because a window is given the icon as it is
      * created and there is nothing here that would go back and fit one to a
      * window that had already appeared without it */
     icon_make();
-
-    w.xkb = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 
     /*
      * No window is opened here. There is nothing to show until GEM opens

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -95,6 +95,7 @@
 #include "screen.h"
 #include "settings.h"
 #include "scraptext.h"
+#include "keyboard.h"
 #include "emuvdi/emuvdi.h"
 
 /* Told to the AES when a window's frame is used to close it, so that the
@@ -1049,7 +1050,7 @@ static void kb_key(void *data, struct wl_keyboard *kb, uint32_t serial,
 {
     xkb_keycode_t code = key + 8;   /* Wayland counts from a different place */
     xkb_keysym_t sym;
-    uint16_t scan, ch = 0;
+    uint16_t scan, word;
     uint32_t cp;
 
     (void)data; (void)kb; (void)time;
@@ -1089,32 +1090,27 @@ static void kb_key(void *data, struct wl_keyboard *kb, uint32_t serial,
         scan = (uint16_t)key;
 
     /*
-     * And what it types, in the ST's alphabet rather than the desktop's.
-     *
-     * The layout is the host's, so the answer is Unicode, and scrap_text_key
-     * is what knows the ST's spelling of it. Asking for the codepoint rather
-     * than for UTF-8 is the point: this used to take the character only when
-     * xkb wrote a single byte, and UTF-8 spends two on every letter outside
-     * ASCII, so a Nordic keyboard typed nothing at all and left the
-     * application to make what it could of a scan code with no character.
-     *
-     * A character the ST has no byte for types nothing, and the scan code
-     * still goes, so a shortcut on such a key keeps working.
+     * And what it types, which the desktop answers in Unicode: the layout is
+     * the host's. Asking for the codepoint rather than for UTF-8 is the point -
+     * this used to take the character only when xkb wrote a single byte, and
+     * UTF-8 spends two on every letter outside ASCII, so a Nordic keyboard
+     * typed nothing at all and left the application to make what it could of a
+     * scan code with no character.
      */
     cp = xkb_state_key_get_utf32(w.xkb_state, code);
 
-    if (cp)
-    {
-        int typed = scrap_text_key(cp);
+    /*
+     * The two halves together, which is keyboard.c's to say: what a modifier
+     * does to a keypress is not something the desktop has an opinion about, and
+     * an application is entitled to the answer TOS gave. Nought is a key GEM
+     * has no way of describing.
+     */
+    word = keyboard_word(scan, cp, gfx_kstate());
 
-        if (typed >= 0)
-            ch = (uint16_t)typed;
-    }
+    if (word == 0)
+        return;
 
-    if (scan == 0 && ch == 0)
-        return;     /* A key GEM has no way of describing */
-
-    key_post((uint16_t)((scan << 8) | ch));
+    key_post(word);
 }
 
 static void kb_modifiers(void *data, struct wl_keyboard *kb, uint32_t serial,

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -309,6 +309,24 @@ void gfx_mouse_now(int16_t *x, int16_t *y, int16_t *buttons);
  * it has: nought,nought is a real place, and things happen there. */
 int gfx_mouse_known(void);
 uint16_t gfx_kstate();
+
+/*
+ * The keyboard table as the keyboard somebody is typing on, which is three
+ * arrays of a hundred and twenty eight bytes: what each key of the machine
+ * types unshifted, shifted, and with caps lock down.
+ *
+ * An application reads it through XBIOS Keytbl to ask which letter is on the
+ * key that arrived, a menu shortcut being a key rather than a character - so
+ * the answer has to come from the layout in front of the person. Only the keys
+ * where a scan code and a Linux key number are the same number are filled in,
+ * and only where the desktop says the key types something: everything else is
+ * left as the caller had it, which is the table the machine came with.
+ *
+ * Answers whether there was anybody to ask. A run with no window is not, and
+ * the caller then has what it started with.
+ */
+int gfx_keyboard_table(uint8_t *norm, uint8_t *shift, uint8_t *caps);
+
 /*
  * The next time the buttons changed, with where the pointer was when they did,
  * or 0 if they have not changed since this was last asked.

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -1,0 +1,198 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * What a modified key press becomes.
+ *
+ * A keypress reaches an application as one word: which key, and what it typed.
+ * Putting the two together is not a matter of writing them side by side,
+ * because a modifier changes the word rather than being reported beside it -
+ * which is what makes this worth a file of its own.
+ *
+ * Alternate and a letter is the case that matters most. It types nothing, and
+ * TOS says so by leaving the character empty and sending the key alone: that is
+ * how a menu shortcut is told from somebody typing. An application gets the
+ * letter back by looking the key up in the keyboard table - see XBIOS Keytbl -
+ * so Alternate-L arrives as the key where L is with nothing typed, and an
+ * application matching it against the L on its own menu finds it whatever
+ * alphabet the keyboard is arranged in.
+ *
+ * Shift and a function key is a different key rather than a modified one: F1 to
+ * F10 become F11 to F20, which is a second row of ten an ST keyboard has no
+ * caps for and every editor of the period used. Control and a cursor key is the
+ * same idea - Control-left is a key of its own, and an application waiting for
+ * it never sees Control at all.
+ *
+ * All of it is EmuTOS's, in convert_scancode in bios/ikbd.c, which is the
+ * authority: these are the rules the keyboard interrupt applied before anything
+ * else saw the key, so an application was written knowing them and cannot be
+ * told otherwise. What is not here is what that interrupt did with the keyboard
+ * table, because there is no table on this side of the seam: the host says what
+ * a key typed, in Unicode, and scrap_text_key knows the ST's spelling of it.
+ */
+
+#include "keyboard.h"
+
+#include "scraptext.h"
+
+/* The keys a modifier does not change, and what each of them types. Every ST
+ * keyboard table spells these the same way, whatever country it was sold in,
+ * which is why they can be answered here rather than looked up. */
+#define KEY_ESCAPE     (0x01)
+#define KEY_BACKSPACE  (0x0e)
+#define KEY_TAB        (0x0f)
+#define KEY_RETURN     (0x1c)
+#define KEY_UNDO       (0x61)
+#define KEY_ENTER      (0x72)   /* the one on the keypad */
+
+/* The keys the rules below move */
+#define TOPROW_FIRST   (0x02)   /* the digits, minus and equals */
+#define TOPROW_LAST    (0x0d)
+#define ALT_TOPROW     (0x76)   /* what Alternate adds to one of those */
+
+#define KEY_F1         (0x3b)
+#define KEY_F10        (0x44)
+#define SHIFT_FKEY     (0x19)   /* what Shift adds, making F11 to F20 */
+
+#define KEY_HOME       (0x47)
+#define KEY_LEFT       (0x4b)
+#define KEY_RIGHT      (0x4d)
+#define KEY_CTRL_HOME  (0x77)
+#define KEY_CTRL_LEFT  (0x73)
+#define KEY_CTRL_RIGHT (0x74)
+
+static uint16_t word_of(uint16_t scancode, uint16_t ch)
+{
+    return (uint16_t)((scancode << 8) | ch);
+}
+
+uint16_t keyboard_word(uint16_t scancode, uint32_t codepoint, uint16_t held)
+{
+    uint16_t ch = 0;
+
+    /*
+     * The keys that type the same thing however they are held.
+     *
+     * They are answered first and without asking the desktop, because the
+     * desktop does not always agree: Shift and Tab is a keysym of its own
+     * there and types nothing, where on an ST it is a tab with a shift key
+     * held - which is what a dialog reads to go back a field rather than on to
+     * the next one.
+     */
+    switch (scancode)
+    {
+        case KEY_RETURN:
+        case KEY_ENTER:
+            /* Control turning a Return into a line feed is the one exception,
+             * and it is TOS's rather than a convenience */
+            return word_of(scancode, (held & KEYBOARD_CTRL) ? 0x0a : 0x0d);
+
+        case KEY_ESCAPE:
+            return word_of(scancode, 0x1b);
+        case KEY_BACKSPACE:
+            return word_of(scancode, 0x08);
+        case KEY_TAB:
+            return word_of(scancode, 0x09);
+        case KEY_UNDO:
+            return word_of(scancode, 0);
+
+        default:
+            break;
+    }
+
+    if (codepoint)
+    {
+        int typed = scrap_text_key(codepoint);
+
+        if (typed >= 0)
+            ch = (uint16_t)typed;
+    }
+
+    /*
+     * Alternate, or Shift, and never both: an ST reads the two in that order
+     * and stops at the first, so Alternate-Shift-F1 is Alternate-F1 with a
+     * shift key held rather than Alternate-F11.
+     */
+    if (held & KEYBOARD_ALT)
+    {
+        /* Alternate and one of the digits is a key of its own, well past the
+         * ones an ST keyboard has, and it types nothing */
+        if (scancode >= TOPROW_FIRST && scancode <= TOPROW_LAST)
+            return word_of((uint16_t)(scancode + ALT_TOPROW), 0);
+
+        /* And Alternate and a letter is the key alone, which is the whole of
+         * how a shortcut is told from a letter somebody meant */
+        if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z'))
+            ch = 0;
+    }
+    else if (held & KEYBOARD_SHIFT)
+    {
+        if (scancode >= KEY_F1 && scancode <= KEY_F10)
+            return word_of((uint16_t)(scancode + SHIFT_FKEY), 0);
+    }
+
+    if (held & KEYBOARD_CTRL)
+    {
+        /*
+         * The three cursor keys Control turns into keys of their own. Their
+         * character is left as it is, there being none: what an application
+         * waits for is the key.
+         */
+        switch (scancode)
+        {
+            case KEY_HOME:
+                scancode = KEY_CTRL_HOME;
+                break;
+            case KEY_LEFT:
+                scancode = KEY_CTRL_LEFT;
+                break;
+            case KEY_RIGHT:
+                scancode = KEY_CTRL_RIGHT;
+                break;
+
+            /*
+             * Everything else is the character with its top three bits taken
+             * off, which is what makes Control-A a one and Control-1 an eleven.
+             * The desktop has already done that much for the letters, and for
+             * the two an ST answers oddly - Control-2 is a nought and Control-6
+             * a thirty - because it folds those the same way. Folding again
+             * leaves all of them as they are and settles the keys the desktop
+             * left alone, so there is one rule here rather than a list of which
+             * keys arrived folded already.
+             *
+             * Minus is the one the fold gets wrong. An ST answers it with 0x1f
+             * and the fold makes it a Return, which is not a curiosity: it is a
+             * real key beside the digits, and an editor watching for
+             * Control-minus would act on Return instead.
+             */
+            default:
+                if (ch == '-')
+                    ch = 0x1f;
+
+                ch &= 0x1f;
+                break;
+        }
+    }
+
+    if (scancode == 0 && ch == 0)
+        return 0;
+
+    return word_of(scancode, ch);
+}

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -1,0 +1,47 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef KEYBOARD_H
+#define KEYBOARD_H
+
+#include <stdint.h>
+
+/* The bits a caller says a modifier is held with, which are the bits GEM
+ * reports them in, include/biosdefs.h */
+#define KEYBOARD_RSHIFT (0x01)
+#define KEYBOARD_LSHIFT (0x02)
+#define KEYBOARD_SHIFT  (KEYBOARD_RSHIFT|KEYBOARD_LSHIFT)
+#define KEYBOARD_CTRL   (0x04)
+#define KEYBOARD_ALT    (0x08)
+
+/*
+ * What a key press becomes, which is one word: the scan code of the key in the
+ * top half and the character it typed in the bottom.
+ *
+ * The scan code is a place on an ST keyboard and the character is a byte of the
+ * ST's alphabet, so the caller hands over both halves as the host reports them
+ * - a scan code from where the key is, and the character as Unicode - along
+ * with which modifiers were held. Nought is answered for a press there is no
+ * way to describe, which is neither a key an ST has nor a character it has a
+ * byte for.
+ */
+uint16_t keyboard_word(uint16_t scancode, uint32_t codepoint, uint16_t held);
+
+#endif /* KEYBOARD_H */

--- a/src/keyboardtest.c
+++ b/src/keyboardtest.c
@@ -1,0 +1,171 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * What a modified key press becomes.
+ *
+ * Built for the host rather than for the emulated machine, because a modifier
+ * is not something a test can hold down. TOSEMU_KEYS hands over characters and
+ * has nowhere to say that Alternate was down while one arrived, and a
+ * compositor - which is the only other thing that reports a keypress - is not
+ * something a test can arrange either. So the rules are a function of their
+ * own and the words are handed to it here.
+ *
+ * What is checked is that the word an application is given is the word TOS
+ * would have given it, which is the whole of why menu shortcuts work: an
+ * application looks for the key rather than for the letter, and a word with a
+ * letter in it is somebody typing.
+ */
+
+#include "keyboard.h"
+
+#include <stdio.h>
+
+static int n;
+static int fails;
+
+static void check(long got, long want, const char *name)
+{
+    n++;
+    if (got == want)
+        printf("ok %d - %s\n", n, name);
+    else
+    {
+        fails++;
+        printf("not ok %d - %s (got 0x%04lx, want 0x%04lx)\n",
+               n, name, got, want);
+    }
+}
+
+/* The scan codes this asks about, which are places on an ST keyboard */
+#define KEY_1       (0x02)
+#define KEY_L       (0x26)
+#define KEY_MINUS   (0x0c)
+#define KEY_A       (0x1e)
+#define KEY_F1      (0x3b)
+#define KEY_F4      (0x3e)
+#define KEY_F10     (0x44)
+#define KEY_LEFT    (0x4b)
+#define KEY_RIGHT   (0x4d)
+#define KEY_HOME    (0x47)
+#define KEY_UP      (0x48)
+#define KEY_TAB     (0x0f)
+#define KEY_RETURN  (0x1c)
+
+int main(int argc, char **argv)
+{
+    (void)argc; (void)argv;
+
+    /* Nothing held: the key and what it typed, side by side */
+    check(keyboard_word(KEY_L, 'l', 0), 0x266c,
+          "a letter is the key and the letter");
+    check(keyboard_word(KEY_L, 'L', KEYBOARD_LSHIFT), 0x264c,
+          "and shifted it is the same key and a capital");
+
+    /*
+     * Alternate and a letter, which is what a menu shortcut is. The character
+     * has to go: an application looks the key up in the keyboard table to get
+     * the letter back, and one that arrives with a letter in it is a letter
+     * somebody typed.
+     */
+    check(keyboard_word(KEY_L, 'l', KEYBOARD_ALT), 0x2600,
+          "Alternate and a letter is the key alone");
+    check(keyboard_word(KEY_L, 'L', KEYBOARD_ALT|KEYBOARD_LSHIFT), 0x2600,
+          "and so is Alternate, Shift and a letter");
+
+    /* Alternate and one of the digits is a key of its own, well past the ones
+     * an ST keyboard has, and it types nothing either */
+    check(keyboard_word(KEY_1, '1', KEYBOARD_ALT), 0x7800,
+          "Alternate and a digit is a key of its own");
+
+    /*
+     * Shift and a function key is the second row of ten an ST keyboard has no
+     * caps for. Both ends of the row, because an off-by-one here is an
+     * application acting on the wrong command rather than on none.
+     */
+    check(keyboard_word(KEY_F1, 0, KEYBOARD_LSHIFT), 0x5400,
+          "Shift and F1 is F11");
+    check(keyboard_word(KEY_F4, 0, KEYBOARD_RSHIFT), 0x5700,
+          "Shift and F4 is F14");
+    check(keyboard_word(KEY_F10, 0, KEYBOARD_LSHIFT), 0x5d00,
+          "Shift and F10 is F20");
+    check(keyboard_word(KEY_F1, 0, 0), 0x3b00,
+          "and F1 on its own is still F1");
+
+    /* Alternate wins over Shift, the ST reading the two in that order */
+    check(keyboard_word(KEY_F1, 0, KEYBOARD_ALT|KEYBOARD_LSHIFT), 0x3b00,
+          "Alternate and Shift and a function key is not the second row");
+
+    /* Control and the three cursor keys that become keys of their own */
+    check(keyboard_word(KEY_LEFT, 0, KEYBOARD_CTRL), 0x7300,
+          "Control and left is a key of its own");
+    check(keyboard_word(KEY_RIGHT, 0, KEYBOARD_CTRL), 0x7400,
+          "and so is Control and right");
+    check(keyboard_word(KEY_HOME, 0, KEYBOARD_CTRL), 0x7700,
+          "and Control and home");
+    check(keyboard_word(KEY_UP, 0, KEYBOARD_CTRL), 0x4800,
+          "while the cursor keys that do not are left where they are");
+
+    /*
+     * Control and a character, which is the character with its top three bits
+     * taken off. The letters arrive folded already, because the desktop folds
+     * them the same way; the digits do not.
+     */
+    check(keyboard_word(KEY_A, 0x01, KEYBOARD_CTRL), 0x1e01,
+          "Control and a letter is a control character");
+    check(keyboard_word(KEY_1, '1', KEYBOARD_CTRL), 0x0211,
+          "Control and a digit is folded the same way");
+    check(keyboard_word(KEY_MINUS, '-', KEYBOARD_CTRL), 0x0c1f,
+          "Control and minus is the one the fold gets wrong");
+
+    /*
+     * A character the ST has no byte for types nothing and the key still goes,
+     * so a shortcut on such a key keeps working. U+20AC is the Euro sign,
+     * which an ST predates.
+     */
+    check(keyboard_word(KEY_L, 0x20ac, 0), 0x2600,
+          "a character the ST has no byte for is the key alone");
+
+    /* An accented letter is the ST's byte for it rather than the desktop's */
+    check(keyboard_word(KEY_L, 0xe5, 0), 0x2686,
+          "and one it does have is spelled the ST's way");
+
+    /*
+     * The keys that type the same thing however they are held. Shift and Tab
+     * is the one the desktop disagrees about: it has a keysym of its own there
+     * and types nothing, where on an ST it is a tab with a shift key held -
+     * which is what a dialog reads to go back a field.
+     */
+    check(keyboard_word(KEY_TAB, 0, KEYBOARD_LSHIFT), 0x0f09,
+          "Shift and Tab is still a tab");
+    check(keyboard_word(KEY_RETURN, 0x0d, 0), 0x1c0d,
+          "Return is a Return");
+    check(keyboard_word(KEY_RETURN, 0x0d, KEYBOARD_CTRL), 0x1c0a,
+          "and Control and Return is a line feed");
+
+    /* Neither a key nor a character is not a press anything can be told
+     * about */
+    check(keyboard_word(0, 0, 0), 0,
+          "a press with no key and no character is nothing at all");
+
+    printf("1..%d\n", n);
+
+    return fails ? 1 : 0;
+}

--- a/src/xbios.c
+++ b/src/xbios.c
@@ -23,9 +23,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "tossystem.h"
 #include "memory.h"
+#include "gfx.h"
+#include "emuvdi/emuvdi.h"
 #include "cpu.h"
 #include "m68k.h"
 
@@ -81,41 +84,158 @@ uint32_t XBIOS_Dsp_Available()
 
 /* Keyboard table functions **************************************************/
 
+/*
+ * The keyboard table, which is how an application asks what a key means.
+ *
+ * A KEYTAB is three addresses, and each of them is a hundred and twenty eight
+ * bytes saying what a key of the machine types: unshifted, shifted, and with
+ * caps lock down. Nothing here reads it - what a key types is answered by the
+ * desktop, in keyboard.c - and it exists because an application reads it, for
+ * the question the other way round: which letter is on the key that arrived.
+ *
+ * That is the only way to answer it. A menu shortcut on Alternate and a letter
+ * arrives as a scan code with nothing typed, deliberately, so an application
+ * with a menu of letters looks each one up here. GenST2 does, and it takes the
+ * third table to do it, caps lock being the one that answers with capitals -
+ * so an emulator with no table to hand out is an emulator where no shortcut in
+ * it works, and reading a pointer out of an answer of nought sends it walking
+ * through the exception vectors.
+ *
+ * It has to live in the machine's memory, being an address an application
+ * follows, so it comes out of the RAM the system reserves for the structures
+ * it hands pointers to.
+ */
+#define KEYTAB_TABLES (3)
+#define KEYTAB_KEYS   (128)
+
+/* Where it is in the machine, and where the three tables of tosemu's own are.
+ * A new application gets a new reservation, so both go with the old one - see
+ * the note at the top of xbios_p.h. */
+static uint32_t keytab;
+static uint32_t keytab_own;
+
+static void xbios_keyboard_reset(void)
+{
+    keytab = 0;
+    keytab_own = 0;
+}
+
+/*
+ * Puts the three tables back to the ones this machine came with, which is what
+ * Bioskeys does and what the first call has to do before anything else.
+ */
+static void keytab_defaults(void)
+{
+    if (!keytab)
+        return;
+
+    m68k_write_memory_32(keytab, keytab_own);
+    m68k_write_memory_32(keytab + 4, keytab_own + KEYTAB_KEYS);
+    m68k_write_memory_32(keytab + 8, keytab_own + 2 * KEYTAB_KEYS);
+}
+
+/*
+ * The KEYTAB, made the first time anything asks for one.
+ *
+ * The tables are the machine's own to begin with and then whatever the desktop
+ * can say about the keyboard in front of the person is written over the top,
+ * so that the letter on the key is the letter an application is told about.
+ * Where there is no desktop to ask - a test, a terminal - what is left is the
+ * machine's, which is a table rather than nothing.
+ */
+static uint32_t keytab_build(void)
+{
+    const uint8_t *from[KEYTAB_TABLES];
+    uint8_t built[KEYTAB_TABLES][KEYTAB_KEYS];
+    int asked;
+    int i, j;
+
+    if (keytab)
+        return keytab;
+
+    keytab = bios_static_alloc(KEYTAB_TABLES * 4
+                               + KEYTAB_TABLES * KEYTAB_KEYS);
+    if (!keytab)
+        return 0;
+
+    keytab_own = keytab + KEYTAB_TABLES * 4;
+
+    emuvdi_keyboard_tables(&from[0], &from[1], &from[2]);
+
+    for (i = 0; i < KEYTAB_TABLES; i++)
+        memcpy(built[i], from[i], KEYTAB_KEYS);
+
+    asked = gfx_keyboard_table(built[0], built[1], built[2]);
+
+    /*
+     * Which is worth saying, because it decides what an application makes of
+     * every shortcut it has: the letter on the key somebody pressed, or the
+     * letter that would have been on it on the machine this pretends to be.
+     */
+    if (verbose >= VERBOSE_CONFIG)
+    {
+        printf("tosemu: the keyboard table is %s\n",
+               asked ? "the layout on the desktop"
+                     : "the machine's own, there being no desktop to ask");
+        fflush(stdout);
+    }
+
+    for (i = 0; i < KEYTAB_TABLES; i++)
+        for (j = 0; j < KEYTAB_KEYS; j++)
+            m68k_write_memory_8(keytab_own + i * KEYTAB_KEYS + j, built[i][j]);
+
+    keytab_defaults();
+
+    return keytab;
+}
+
 uint32_t XBIOS_Keytbl()
 {
-    uint32_t unshift = peek_u32(2);
-    uint32_t shift = peek_u32(6);
-    uint32_t capslock = peek_u32(10);
+    uint32_t given[KEYTAB_TABLES];
+    uint32_t block;
+    int i;
+
+    given[0] = peek_u32(2);
+    given[1] = peek_u32(6);
+    given[2] = peek_u32(10);
 
     FUNC_TRACE_ENTER_ARGS {
-        printf("    unshift : 0x%x\n    shift   : 0x%x\n    capslock: 0x%x\n", unshift, shift, capslock);
+        printf("    unshift : 0x%x\n    shift   : 0x%x\n    capslock: 0x%x\n",
+               given[0], given[1], given[2]);
     }
 
-    /* TODO to support writing to these tables, the keyboard mapping needs to
-     * be supported in general. At the moment, the system relies on the mapping
-     * of the host system.
+    block = keytab_build();
+    if (!block)
+        return 0;
+
+    /*
+     * A table of the application's own, for each of the three it named. -1 is
+     * how it says to leave one alone, which is what every application asking
+     * where the tables are says for all three.
+     *
+     * What it hands over is an address in its own memory and it stays there:
+     * the table is not copied, because the application is entitled to write to
+     * it afterwards and expect the change to be seen. Nothing here reads these
+     * anyway - a key is turned into a character by the desktop - so what this
+     * is keeping is the answer to the next application that asks.
      */
-    if (unshift != 0xffffffff)
-    {
-        printf("XBIOS Keytbl: Altering the keyboard table is not supported (unshift)\n"); /* TODO */
-        halt_execution();
-    }
-    if (shift != 0xffffffff)
-    {
-        printf("XBIOS Keytbl: Altering the keyboard table is not supported (shift)\n"); /* TODO */
-        halt_execution();
-    }
-    if (capslock != 0xffffffff)
-    {
-        printf("XBIOS Keytbl: Altering the keyboard table is not supported (capslock)\n"); /* TODO */
-        halt_execution();
-    }
+    for (i = 0; i < KEYTAB_TABLES; i++)
+        if (given[i] != 0xffffffff)
+            m68k_write_memory_32(block + i * 4, given[i]);
 
-    return 0; /* TODO return a pointer to the table in some pre-allocated place in ST RAM */
+    return block;
 }
+
 uint32_t XBIOS_Bioskeys()
 {
-    /* TODO this is a nop, as we do not use the keyboard tables at the moment */
+    FUNC_TRACE_ENTER
+
+    /* Which is only worth doing if somebody has asked for the tables at all:
+     * putting them back means having them, and having them means a reservation
+     * this need not make on its own account. */
+    if (keytab_build())
+        keytab_defaults();
+
     return 0;
 }
 
@@ -327,6 +447,7 @@ void xbios_reset()
 {
     xbios_screen_reset();
     xbios_dev_reset();
+    xbios_keyboard_reset();
 }
 
 void xbios_trap()

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,7 +19,7 @@
 STESTNAME=Pterm Pterm0 Cconout Cconws Bconout Fstraversal \
           Fopen Fclose Fread Supexec Dcreate Fcreate Fwrite Fdelete Fattrib \
           cmdline Malloc
-CTESTNAME=c-helloworld c-drives c-bios c-xbios c-console c-super c-linea c-mxalloc c-memory c-pexec c-pexchild c-overlay c-gem c-vdi c-gdos c-print c-prnchild c-aesd c-acc c-userdef c-icon c-boxchar c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-scrap c-poll c-keyboard c-modal
+CTESTNAME=c-helloworld c-drives c-bios c-xbios c-console c-super c-linea c-mxalloc c-memory c-pexec c-pexchild c-overlay c-gem c-vdi c-gdos c-print c-prnchild c-aesd c-acc c-userdef c-icon c-boxchar c-fsel c-watchbox c-mkstate c-screen c-menu c-frame c-resize c-scrap c-poll c-keyboard c-modal c-keytbl
 
 # The ones that call the AES or the VDI, whose bindings live in their own
 # library rather than in the C one
@@ -449,6 +449,17 @@ check: all
 	TOSEMU_CLICKS='@32,8 @96,8 @100,27 100,27 120,152 120,152' \
 	  $(TOSEMU) test-c-modal > out; ! grep -q '^not ok' out
 	grep -q '^1\.\.' out
+	# The keyboard table, which is how a key becomes a letter again: a menu
+	# shortcut on Alternate and a letter arrives as a scan code with nothing
+	# typed, so an application turns it back into a letter through this. The
+	# letters expected are the ones the machine came with, which is what
+	# there is to hand over with no desktop to ask about the keyboard
+	# somebody is really typing on - and this runs with no window. The count
+	# is pinned because the first check is the one that decides whether the
+	# rest can safely run at all: an application cannot follow a table that
+	# is not there, and neither can this.
+	$(TOSEMU) test-c-keytbl > out; ! grep -q '^not ok' out
+	grep -q '^1\.\.17' out
 	# Asking where the mouse is rather than waiting for it, which is what an
 	# application tracking a slider does. The pointer is moved twice and
 	# then pressed and not let go of, and none of it is waited for.

--- a/tests/c-keytbl.c
+++ b/tests/c-keytbl.c
@@ -1,0 +1,142 @@
+/*
+ * TOSEMU - an emulated environment for TOS applications
+ * Copyright (C) 2026 Johan Toverland Thelin <e8johan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+/*
+ * The keyboard table, which is how a key becomes a letter again.
+ *
+ * A menu shortcut on Alternate and a letter arrives as a scan code with
+ * nothing typed - that is how TOS says a key was pressed rather than typed -
+ * so an application with a menu full of letters has to turn the scan code back
+ * into one, and Keytbl is where it gets the alphabet to do it with. An
+ * application that reads a pointer out of an answer of nought walks through the
+ * exception vectors instead, and every shortcut it has resolves to whatever is
+ * lying there.
+ *
+ * So this asks for the three tables and reads the letters out of them. The
+ * letters it expects are the ones on the keyboard a machine came with, which
+ * is what tosemu hands over when there is no desktop to ask about the keyboard
+ * somebody is really typing on - a test has none, and a run with a compositor
+ * and a keyboard laid out some other way would rightly answer differently.
+ *
+ * Then it hands over a table of its own, which an application setting up its
+ * own alphabet is entitled to do, and asks for Bioskeys to put the machine's
+ * back.
+ */
+
+#include <stdio.h>
+#include <mint/osbind.h>
+#include <mint/ostruct.h>
+
+static int n;
+
+static void check(long got, long want, const char *name)
+{
+    n++;
+    if (got == want)
+        printf("ok %d - %s\n", n, name);
+    else
+        printf("not ok %d - %s (got %ld, want %ld)\n", n, name, got, want);
+}
+
+/* Where the letters this asks about sit on an ST keyboard */
+#define KEY_A       (0x1e)
+#define KEY_S       (0x1f)
+#define KEY_L       (0x26)
+#define KEY_C       (0x2e)
+#define KEY_TAB     (0x0f)
+#define KEY_RETURN  (0x1c)
+#define KEY_SPACE   (0x39)
+#define KEY_HOME    (0x47)
+
+/* A table of an application's own, which is the whole of what one has to be:
+ * a hundred and twenty eight bytes, a key to each */
+static char mine[128];
+
+int main(int argc, char **argv)
+{
+    _KEYTAB *tab, *again;
+
+    tab = (_KEYTAB *)Keytbl((void *)-1L, (void *)-1L, (void *)-1L);
+
+    /* Nought is what this used to answer, and it is the answer an application
+     * cannot do anything with: what it does next is follow it */
+    check(tab != 0, 1, "there is a keyboard table to be had");
+    if (!tab)
+    {
+        printf("1..%d\n", n);
+        return 1;
+    }
+
+    check(tab->unshift != 0 && tab->shift != 0 && tab->caps != 0, 1,
+          "and all three of its tables are somewhere");
+
+    /*
+     * The letters, read out of the third table. That is the one an application
+     * matching a menu shortcut wants, capitals being what a menu says, and it
+     * is the one GenST2 takes.
+     */
+    check(tab->caps[KEY_A], 'A', "the key where A is says so");
+    check(tab->caps[KEY_S], 'S', "and the key where S is");
+    check(tab->caps[KEY_L], 'L', "and the key where L is");
+    check(tab->caps[KEY_C], 'C', "and the key where C is");
+
+    /* And the other two, which are the same keys in the other two states */
+    check(tab->unshift[KEY_A], 'a', "unshifted it is a small letter");
+    check(tab->shift[KEY_A], 'A', "and shifted it is a capital again");
+
+    /* The keys that are not letters and are the same on every keyboard */
+    check(tab->unshift[KEY_TAB], 9, "the tab key types a tab");
+    check(tab->unshift[KEY_RETURN], 13, "and Return a carriage return");
+    check(tab->unshift[KEY_SPACE], ' ', "and the space bar a space");
+
+    /*
+     * The cursor keys type nothing, and that is worth asking about: an ST has
+     * them where a PC keyboard has its keypad, so a table built by asking the
+     * desktop what the key at that number does would put a digit here.
+     */
+    check(tab->unshift[KEY_HOME], 0, "and the Home key types nothing");
+
+    /* Asking twice is asking about one table rather than making another */
+    again = (_KEYTAB *)Keytbl((void *)-1L, (void *)-1L, (void *)-1L);
+    check(again == tab, 1, "asking again is the same table");
+
+    /*
+     * A table of the application's own. It is handed over and kept as it
+     * stands: an application is entitled to write to its own table afterwards
+     * and to have the change seen.
+     */
+    mine[KEY_A] = 'Z';
+    again = (_KEYTAB *)Keytbl(mine, (void *)-1L, (void *)-1L);
+
+    check(again->unshift == mine, 1, "a table of one's own is taken");
+    check(again->shift[KEY_A], 'A', "and the two not named are left alone");
+
+    /* And Bioskeys puts the machine's own back, which is what an application
+     * does before it goes away */
+    Bioskeys();
+    again = (_KEYTAB *)Keytbl((void *)-1L, (void *)-1L, (void *)-1L);
+
+    check(again->unshift != mine, 1, "Bioskeys gives the machine's own back");
+    check(again->unshift[KEY_A], 'a', "and they say what they said before");
+
+    printf("1..%d\n", n);
+
+    return 0;
+}


### PR DESCRIPTION
The modifiers and keyboard look-up tables (conversion between keys and characters) did not work as intended. Implementing this now.