### PR TITLE
screen: a native screen the desktop's panel does not reach into

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,11 +255,22 @@ one of the two, and `.gitignore` covers them. Do not commit changes inside
 ## Screens
 
 `TOSEMU_SCREEN` picks one, and `screen.c` holds the table. The ST's `low`,
-`medium` and `high`; the TT's `tt-medium` and `tt-high`; and `native-mono` and
-`native-color`, which are as large as the display will hold. `high` is the
-default because it is what GEM applications were written for — 640x400, eighty
+`medium` and `high`; the TT's `tt-medium` and `tt-high`; `native-mono` and
+`native-color`, which are as large as a window may be; and `display-mono` and
+`display-color`, which are as large as the display is. `high` is the default
+because it is what GEM applications were written for — 640x400, eighty
 characters across. A dialog out of a resource is measured in characters, so how
 many fit is what decides whether it fits at all.
+
+The difference between the last two pairs is the desktop's panel, and finding
+it is the one thing in `screen.c` that is not arithmetic: Wayland has no work
+area, so the size a maximised window would be given is asked for and that is
+the panel subtracted by the compositor. It is asked on a surface that is
+committed with no buffer and destroyed again, so nothing appears — see
+`ask_for_maximized`, and `wait_for` beside it for why the wait has a clock on
+it. `NO_WAYLAND=1` takes all of it out, and with nothing to ask all four fall
+back to 640x400, which is what the test suite pins with `WAYLAND_DISPLAY`
+pointed at nothing.
 
 The daemon decides when there is one, including for the accessories it starts,
 so `TOSEMU_SCREEN`, `TOSEMU_SCALE` and `TOSEMU_OUTPUT` — or the `[screen]`

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,14 @@ WINDOWICON = $(GEN)/rsc/window-icon.h
 # large the display is amounts to. The daemon wants this and not the rest: it
 # has no windows and no keyboard, and a keymap library it never calls is a
 # dependency it should not have.
+#
+# xdg-shell is in it because one of the two questions screen.c asks is how
+# large a maximised window would be, and maximising is a shell's word rather
+# than a display's. Nothing is shown either way - see ask_for_maximized - so
+# this is still the part of Wayland that has no windows in it.
 WAYLANDONLYLIBS = $(shell pkg-config --libs wayland-client)
+WAYLANDONLYHEADERS = $(GEN)/xdg-shell-client-protocol.h
+WAYLANDONLYOBJECTS = $(OBJ)/gen/xdg-shell-protocol.o
 
 # Building on a machine that has no Wayland to build against.
 #
@@ -104,6 +111,8 @@ WINDOWICON =
 WAYLANDFLAGS = -DNO_WAYLAND
 WAYLANDLIBS =
 WAYLANDONLYLIBS =
+WAYLANDONLYHEADERS =
+WAYLANDONLYOBJECTS =
 endif
 
 EMUVDIFILES = emuvdi/hostvars.c emuvdi/hostfs.c emuvdi/fonts.c emuvdi/keytables.c emuvdi/gdosfnt.c emuvdi/gdosfsm.c emuvdi/prndev.c emuvdi/textblit.c emuvdi/conout.c emuvdi/bridge.c \
@@ -397,7 +406,8 @@ $(GEN)/rsc/window-icon.h: $(EMUTOS)/extras/emuicon1.rsc $(SRC)/rsc/emuicon-to-c.
 	@mkdir -p $(dir $@)
 	python3 $(SRC)/rsc/emuicon-to-c.py $< 6 $@
 
-$(BIN)/tosaesd: $(DAEMONOBJECTS) $(OBJ)/screen.o $(OBJ)/settings.o
+$(BIN)/tosaesd: $(DAEMONOBJECTS) $(OBJ)/screen.o $(OBJ)/settings.o \
+                $(WAYLANDONLYOBJECTS)
 	@mkdir -p $(BIN)
 	$(LD) $(LDFLAGS) $^ $(DBUSLIBS) $(WAYLANDONLYLIBS) -o $@
 
@@ -406,7 +416,8 @@ $(BIN)/tosaesd: $(DAEMONOBJECTS) $(OBJ)/screen.o $(OBJ)/settings.o
 # is: what is being checked is not something an application can reach. A
 # compositor's answer cannot be arranged by a test, so the asking is checked by
 # using it and the arithmetic is checked here.
-$(BIN)/screentest: $(SRC)/screentest.c $(OBJ)/screen.o $(OBJ)/settings.o
+$(BIN)/screentest: $(SRC)/screentest.c $(OBJ)/screen.o $(OBJ)/settings.o \
+                   $(WAYLANDONLYOBJECTS)
 	@mkdir -p $(BIN)
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(WAYLANDONLYLIBS) -o $@
 
@@ -541,6 +552,12 @@ $(GEN)/xdg-toplevel-icon-v1-client-protocol.h:
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS)/staging/xdg-toplevel-icon/xdg-toplevel-icon-v1.xml $@
 
 $(OBJ)/gfx.o: $(WAYLANDHEADERS) $(WINDOWICON)
+
+# And screen.o the one of them that says how large a maximised window is. It
+# is here rather than left to the .d files for the same reason the line above
+# is: on a first build there is no .d yet, and the header has to exist before
+# the compiler goes looking for it.
+$(OBJ)/screen.o: $(WAYLANDONLYHEADERS)
 
 # Every object needs the generated m68kops.h, so none of them may be compiled
 # before m64kmake has run

--- a/README.md
+++ b/README.md
@@ -153,18 +153,29 @@ characters of the same size, so an application gets more room rather than a
 bigger picture. `tt-high` is 1280x960, which at the default scale would be a
 window larger than most displays - set `TOSEMU_SCALE=1` with it.
 
-Two more are a rule rather than a size: `native-mono` and `native-color` are as
-large as the display will hold, in one plane and in four. They are not Atari
-screens and are not pretending to be. What they are for is a GEM application
-having the room a modern display has, which is the one thing the machine could
-not give it - and the rest of GEM does not mind, because a resource is measured
-in characters and more of them across is simply more room.
+Four more are a rule rather than a size: `native-mono` and `native-color` are
+as large as a window may be, in one plane and in four, and `display-mono` and
+`display-color` are as large as the display is. They are not Atari screens and
+are not pretending to be. What they are for is a GEM application having the
+room a modern display has, which is the one thing the machine could not give it
+- and the rest of GEM does not mind, because a resource is measured in
+characters and more of them across is simply more room.
 
-How large that is comes out of two divisions. The compositor's own scaling is
-one - a display reporting 3456x2160 at a scale of two shows a window in half of
-those - and `TOSEMU_SCALE` is the other, being how many of those an ST pixel
-becomes. So a 3456x2160 display at scale two gives a 576x360 screen at the
-default `TOSEMU_SCALE=3`, and that screen magnified by three is 1728x1080,
+The difference between the two pairs is the panel. A desktop keeps some of its
+display for itself - a bar across the bottom, a dock down one side - and a
+screen worked out from the whole display is a screen whose bottom right corner
+is behind that bar, which is exactly where a GEM window keeps its size box. So
+`native-mono` and `native-color` ask the compositor how large a window it is
+willing to give, which is what maximising one answers and is the panel
+subtracted by the only party that knows about it. `display-mono` and
+`display-color` measure the display itself, panel or no panel, which is what
+the first pair meant before there was any way to tell the difference.
+
+How large either of them is comes out of two divisions. The compositor's own
+scaling is one - a display reporting 3456x2160 at a scale of two shows a window
+in half of those - and `TOSEMU_SCALE` is the other, being how many of those an
+ST pixel becomes. So a 3456x2160 display at scale two gives a 576x360 screen at
+the default `TOSEMU_SCALE=3`, and that screen magnified by three is 1728x1080,
 which is the display. They are one setting rather than two for exactly that
 reason. The width is rounded down to a multiple of sixteen, because a row of a
 surface is a whole number of words, so the window can come out a little short of
@@ -172,16 +183,31 @@ the display's width and never over it.
 
 `TOSEMU_OUTPUT` says which display to measure, by the name the compositor gives
 it - `eDP-1`, `DP-1` and so on, which `wayland-info` will list. Without it, the
-first one the compositor mentions. With no compositor to ask at all the size
-falls back to 640x400 and the planes stay as asked, which is what happens on a
-machine with no desktop and in the test suite. A display named and not there -
-a monitor since unplugged, most likely - falls back the same way and says which
-displays it did find, rather than quietly measuring a different one.
+first one the compositor mentions, and for the two that maximise, whichever
+display the compositor puts a new window on - which is not always the same one,
+and is the display the emulator's own windows are about to appear on either
+way. A maximised window cannot be asked for on a display of one's choosing:
+xdg-shell has that for fullscreen and nothing of the kind for maximising. So
+when a display is named, what carries across is how much room the desktop took
+rather than the size it left - the same panel is on every display of a desk
+that has one - and that is taken off the display that was asked for.
 
-Asking costs one round trip at the moment the machine is decided, and no window:
-`wl_output` is a global like any other and says how large it is without anything
-being shown. When `tosaesd` is running it is the one that asks, because it is
-the one that decides - so set these on the daemon, not on each application.
+With no compositor to ask at all the size falls back to 640x400 and the planes
+stay as asked, which is what happens on a machine with no desktop and in the
+test suite. A display named and not there - a monitor since unplugged, most
+likely - falls back the same way and says which displays it did find, rather
+than quietly measuring a different one. So does a compositor that does not
+answer the second question within a quarter of a second, or has no xdg-shell to
+answer it with: `native-*` is then `display-*`, which is a panel in the way and
+not a screen that failed to appear.
+
+Asking costs two round trips at the moment the machine is decided, and no
+window. `wl_output` is a global like any other and says how large it is without
+anything being shown; the maximised size needs a surface, but that surface is
+committed with nothing attached to it, which is a question rather than a
+window, and it is destroyed as soon as the answer arrives. When `tosaesd` is
+running it is the one that asks, because it is the one that decides - so set
+these on the daemon, not on each application.
 
 When `tosaesd` is running it is what decides, and the variable is read from its
 environment rather than from each application's. The screen has to be one
@@ -586,9 +612,9 @@ AES opens the physical workstation with:
 
 | `TOSEMU_SCREEN`             | planes | section |
 | --------------------------- | ------ | ------- |
-| `high`, `tt-high`, `native-mono` | 1 | 4 |
+| `high`, `tt-high`, `native-mono`, `display-mono` | 1 | 4 |
 | `medium`                    | 2      | 3       |
-| `low`, `tt-medium`, `native-color` | 4 | 2 |
+| `low`, `tt-medium`, `native-color`, `display-color` | 4 | 2 |
 
 It matters because the sections usually hold different fonts. A medium
 resolution screen puts two hundred lines where a high resolution one puts four

--- a/src/screen.c
+++ b/src/screen.c
@@ -42,6 +42,12 @@
 
 #ifndef NO_WAYLAND
 #include <wayland-client.h>
+#include "xdg-shell-client-protocol.h"
+
+/* For the wait that gives up - see wait_for */
+#include <errno.h>
+#include <poll.h>
+#include <time.h>
 #endif
 
 /* How much larger than an ST pixel one on the desktop is. Three is a
@@ -111,21 +117,33 @@ static const struct {
 #define MODE_DEFAULT (2)    /* high */
 
 /*
- * And the two that are a rule: as large as the display will hold, in colour or
- * in black and white.
+ * And the four that are a rule rather than a size: as much room as there is,
+ * in colour or in black and white.
  *
  * They are not Atari screens and are not pretending to be. What they are for
  * is a GEM application having the room a modern display has, which is the one
  * thing the machine could not give it - the rest of GEM does not mind, because
  * a resource is measured in characters and more of them across is simply more
  * room.
+ *
+ * What "will hold" means is the difference between the two pairs. A desktop
+ * keeps some of its display for itself - a panel across the bottom, a dock
+ * down one side - and a screen worked out from the whole display is a screen
+ * whose bottom right corner is behind that panel, which is where a GEM
+ * window's size box is. So native-mono and native-color are as large as a
+ * window may be, which is what maximising one answers; display-mono and
+ * display-color are the display itself, panel or no panel, which is what
+ * these two meant before there was any way to tell the difference.
  */
 static const struct {
     const char *name;
     int16_t planes;
+    int work;               /* the room a window has rather than the display */
 } native[] = {
-    { "native-mono",  1 },
-    { "native-color", 4 },
+    { "native-mono",   1, 1 },
+    { "native-color",  4, 1 },
+    { "display-mono",  1, 0 },
+    { "display-color", 4, 0 },
 };
 
 void screen_from_display(int32_t pixels_w, int32_t pixels_h, int32_t out_scale,
@@ -179,13 +197,46 @@ void screen_from_display(int32_t pixels_w, int32_t pixels_h, int32_t out_scale,
     *height = (int16_t)h;
 }
 
+void screen_inset(const struct screen_display *displays, int count,
+                  int32_t maximized_w, int32_t maximized_h,
+                  int32_t *inset_w, int32_t *inset_h)
+{
+    int32_t least = -1;
+    int i;
+
+    *inset_w = 0;
+    *inset_h = 0;
+
+    /* A compositor that maximised a window to nothing has said nothing */
+    if (maximized_w <= 0 || maximized_h <= 0)
+        return;
+
+    for (i = 0; i < count; i++)
+    {
+        int32_t scale = displays[i].scale > 0 ? displays[i].scale : 1;
+        int32_t w = displays[i].width / scale - maximized_w;
+        int32_t h = displays[i].height / scale - maximized_h;
+
+        /* A window is not maximised to more than the display it is on, so a
+         * display it does not fit inside is not the display it went to */
+        if (w < 0 || h < 0)
+            continue;
+
+        if (least < 0 || w + h < least)
+        {
+            least = w + h;
+            *inset_w = w;
+            *inset_h = h;
+        }
+    }
+}
+
 #ifndef NO_WAYLAND
 
 /* What the compositor said about one display */
 struct display {
     char name[64];
-    int32_t width, height;      /* the mode it is in, in its own pixels */
-    int32_t scale;
+    struct screen_display size;
     int known;                  /* whether a mode ever arrived for it */
 };
 
@@ -194,6 +245,11 @@ struct display {
 static struct {
     struct display display[DISPLAYS];
     int count;
+
+    /* And what is needed to ask the other question, which is how large a
+     * window the desktop leaves room for - see ask_for_maximized */
+    struct wl_compositor *compositor;
+    struct xdg_wm_base *wm_base;
 } found;
 
 /*
@@ -222,8 +278,8 @@ static void output_mode(void *data, struct wl_output *output, uint32_t flags,
     if (!(flags & WL_OUTPUT_MODE_CURRENT))
         return;
 
-    d->width = width;
-    d->height = height;
+    d->size.width = width;
+    d->size.height = height;
     d->known = 1;
 }
 
@@ -238,7 +294,7 @@ static void output_scale(void *data, struct wl_output *output, int32_t factor)
 
     (void)output;
 
-    d->scale = factor;
+    d->size.scale = factor;
 }
 
 static void output_name(void *data, struct wl_output *output, const char *name)
@@ -265,6 +321,248 @@ static const struct wl_output_listener output_listener = {
     output_description
 };
 
+/*
+ * How large a window the desktop leaves room for, which is not a thing
+ * Wayland has an answer to.
+ *
+ * There is no work area in the protocol. A compositor says how large its
+ * displays are and never what it has put on them, so a panel across the
+ * bottom is invisible to a client - and a screen worked out from the whole
+ * display is a screen whose last rows are behind that panel. Which is where a
+ * GEM window keeps its size box.
+ *
+ * What there is instead is maximising, which is the compositor being asked for
+ * the largest window it is willing to give and answering with a size. That
+ * answer is the panel, the dock and the frame it draws itself, all subtracted
+ * by the one party that knows about them.
+ *
+ * It is asked without a window ever appearing. A surface is made, a shell is
+ * asked for a toplevel, the toplevel is asked to be maximised and the surface
+ * is committed with nothing attached to it - which is the handshake every
+ * Wayland window begins with, and a surface with no buffer is not shown. The
+ * configure that comes back carries the size. Then all three are destroyed,
+ * and nothing was ever on the display.
+ */
+struct maximized {
+    int32_t width, height;
+    int configured;
+};
+
+/* Wayland asks to be told the connection is still wanted */
+static void wm_base_ping(void *data, struct xdg_wm_base *base, uint32_t serial)
+{
+    (void)data;
+    xdg_wm_base_pong(base, serial);
+}
+
+static const struct xdg_wm_base_listener wm_base_listener = {
+    wm_base_ping
+};
+
+/* The size arrives on the toplevel and the go-ahead on the surface under it,
+ * in that order, so this is what says the answer is complete */
+static void probe_surface_configure(void *data, struct xdg_surface *surface,
+                                    uint32_t serial)
+{
+    struct maximized *m = data;
+
+    xdg_surface_ack_configure(surface, serial);
+    m->configured = 1;
+}
+
+static const struct xdg_surface_listener probe_surface_listener = {
+    probe_surface_configure
+};
+
+static void probe_toplevel_configure(void *data, struct xdg_toplevel *toplevel,
+                                     int32_t width, int32_t height,
+                                     struct wl_array *states)
+{
+    struct maximized *m = data;
+
+    (void)toplevel; (void)states;
+
+    /* The states say maximised, which is the only thing that was asked for
+     * and so the only thing it can be. What is wanted is the size. */
+    m->width = width;
+    m->height = height;
+}
+
+static void probe_toplevel_close(void *data, struct xdg_toplevel *toplevel)
+{
+    (void)data; (void)toplevel;
+}
+
+static const struct xdg_toplevel_listener probe_toplevel_listener = {
+    probe_toplevel_configure,
+    probe_toplevel_close
+};
+
+/* Long enough for an answer that is worked out in microseconds, short enough
+ * that a compositor which never answers is a pause and not a hang */
+#define MAXIMIZED_MS (250)
+
+/*
+ * Waiting for one thing to arrive, or for the time to be up.
+ *
+ * wl_display_roundtrip is the usual way and is not this way: it waits for as
+ * long as it takes, and what is being waited for here is a courtesy - the
+ * screen is worked out without it, and a compositor that has stopped talking
+ * should cost the emulator a quarter of a second at startup rather than the
+ * startup itself. So the reading is done by hand, which is the only way to
+ * put a clock on it.
+ */
+static int wait_for(struct wl_display *display, const int *done, int ms)
+{
+    struct timespec started;
+    int fd = wl_display_get_fd(display);
+
+    clock_gettime(CLOCK_MONOTONIC, &started);
+
+    while (!*done)
+    {
+        struct pollfd waiting;
+        struct timespec now;
+        long left;
+        int ready;
+
+        /*
+         * Wayland's own dance for reading events without racing anything
+         * else that might be reading them. Nothing else is, here - this
+         * connection is this function's - but prepare_read is also what says
+         * whether there are events already in hand, and those have to be
+         * handed out before the wait, or the answer could be sitting in the
+         * queue while poll waits for another.
+         */
+        while (wl_display_prepare_read(display) != 0)
+        {
+            if (wl_display_dispatch_pending(display) < 0)
+                return 0;
+        }
+
+        if (wl_display_flush(display) < 0 && errno != EAGAIN)
+        {
+            wl_display_cancel_read(display);
+            return 0;
+        }
+
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        left = ms - ((now.tv_sec - started.tv_sec) * 1000
+                     + (now.tv_nsec - started.tv_nsec) / 1000000);
+        if (left < 0)
+            left = 0;
+
+        waiting.fd = fd;
+        waiting.events = POLLIN;
+        waiting.revents = 0;
+
+        ready = poll(&waiting, 1, (int)left);
+
+        if (ready < 0 && errno == EINTR)
+        {
+            wl_display_cancel_read(display);
+            continue;
+        }
+
+        if (ready <= 0)
+        {
+            wl_display_cancel_read(display);
+            return 0;
+        }
+
+        if (wl_display_read_events(display) < 0)
+            return 0;
+
+        if (wl_display_dispatch_pending(display) < 0)
+            return 0;
+    }
+
+    return 1;
+}
+
+/* Nought for both when there is nobody to ask, nothing to ask with, or no
+ * answer in time - which the caller reads as the desktop keeping none of the
+ * display for itself, and so as the display it already has */
+static void ask_for_maximized(struct wl_display *display,
+                              int32_t *width, int32_t *height)
+{
+    struct maximized m;
+    struct wl_surface *surface;
+    struct xdg_surface *shell_surface;
+    struct xdg_toplevel *toplevel;
+
+    *width = 0;
+    *height = 0;
+
+    /* A compositor with no xdg-shell in it is not one that maximises
+     * anything, and there were desktops like that */
+    if (!found.compositor || !found.wm_base)
+        return;
+
+    memset(&m, 0, sizeof m);
+
+    surface = wl_compositor_create_surface(found.compositor);
+    if (!surface)
+        return;
+
+    shell_surface = xdg_wm_base_get_xdg_surface(found.wm_base, surface);
+    if (!shell_surface)
+    {
+        wl_surface_destroy(surface);
+        return;
+    }
+
+    xdg_surface_add_listener(shell_surface, &probe_surface_listener, &m);
+
+    toplevel = xdg_surface_get_toplevel(shell_surface);
+    if (!toplevel)
+    {
+        xdg_surface_destroy(shell_surface);
+        wl_surface_destroy(surface);
+        return;
+    }
+
+    xdg_toplevel_add_listener(toplevel, &probe_toplevel_listener, &m);
+
+    /* Named as the windows are, because a desktop is entitled to have rules
+     * about a particular application and the answer should be the one the
+     * emulator's own windows would get */
+    xdg_toplevel_set_app_id(toplevel, "se.e8johan.tosemu");
+    xdg_toplevel_set_title(toplevel, "tosemu");
+
+    xdg_toplevel_set_maximized(toplevel);
+
+    /* No buffer, so no window: this is the question and not the showing */
+    wl_surface_commit(surface);
+
+    if (wait_for(display, &m.configured, MAXIMIZED_MS)
+        && m.width > 0 && m.height > 0)
+    {
+        *width = m.width;
+        *height = m.height;
+    }
+
+    xdg_toplevel_destroy(toplevel);
+    xdg_surface_destroy(shell_surface);
+    wl_surface_destroy(surface);
+}
+
+/* screen_inset over the displays this connection heard about, which are the
+ * ones a window could have been maximised onto */
+static void inset_of_found(int32_t maximized_w, int32_t maximized_h,
+                           int32_t *inset_w, int32_t *inset_h)
+{
+    struct screen_display known[DISPLAYS];
+    int count = 0;
+    int i;
+
+    for (i = 0; i < found.count; i++)
+        if (found.display[i].known)
+            known[count++] = found.display[i].size;
+
+    screen_inset(known, count, maximized_w, maximized_h, inset_w, inset_h);
+}
+
 static void registry_global(void *data, struct wl_registry *registry,
                             uint32_t id, const char *interface,
                             uint32_t version)
@@ -274,6 +572,29 @@ static void registry_global(void *data, struct wl_registry *registry,
     uint32_t want;
 
     (void)data;
+
+    /*
+     * The two globals the maximised size is asked through, at the lowest
+     * version that answers: a surface is made and a shell is asked what size
+     * it would give it, and neither of those grew a new way of being done.
+     * gfx.c binds the same shell at the same version, which is what keeps its
+     * listener two entries long and this one likewise.
+     */
+    if (strcmp(interface, wl_compositor_interface.name) == 0)
+    {
+        found.compositor = wl_registry_bind(registry, id,
+                                            &wl_compositor_interface, 1);
+        return;
+    }
+
+    if (strcmp(interface, xdg_wm_base_interface.name) == 0)
+    {
+        found.wm_base = wl_registry_bind(registry, id,
+                                         &xdg_wm_base_interface, 1);
+        if (found.wm_base)
+            xdg_wm_base_add_listener(found.wm_base, &wm_base_listener, 0);
+        return;
+    }
 
     if (strcmp(interface, wl_output_interface.name) != 0)
         return;
@@ -293,7 +614,7 @@ static void registry_global(void *data, struct wl_registry *registry,
         return;
 
     d = &found.display[found.count++];
-    d->scale = 1;
+    d->size.scale = 1;
 
     wl_output_add_listener(output, &output_listener, d);
 }
@@ -310,25 +631,29 @@ static const struct wl_registry_listener registry_listener = {
 };
 
 /*
- * Asks the compositor how large the display is.
+ * Asks the compositor how large the display is, and how much of it a window
+ * may have.
  *
- * No window, and no surface of any kind: wl_output is a global like any other,
- * and what it has to say arrives on a roundtrip. That is what makes this
- * possible at all, because the screen has to exist before anything can be
- * shown in it - a window is opened onto a screen rather than the other way
- * about.
+ * No window, and until the second question no surface of any kind: wl_output
+ * is a global like any other, and what it has to say arrives on a roundtrip.
+ * That is what makes this possible at all, because the screen has to exist
+ * before anything can be shown in it - a window is opened onto a screen rather
+ * than the other way about. The surface the second question needs is never
+ * shown either; see ask_for_maximized.
  *
  * A connection of its own rather than the one gfx.c makes, because the daemon
- * has no gfx.c and asks the same question. It is one round trip once, at the
- * moment the machine is being decided.
+ * has no gfx.c and asks the same question. It is two round trips and a wait
+ * once, at the moment the machine is being decided.
  */
-static int ask_the_compositor(int32_t *pixels_w, int32_t *pixels_h,
-                              int32_t *out_scale)
+static int ask_the_compositor(int want_work, int32_t *pixels_w,
+                              int32_t *pixels_h, int32_t *out_scale)
 {
     struct wl_display *display;
     struct wl_registry *registry;
     const char *wanted = setting("TOSEMU_OUTPUT");
     struct display *picked = 0;
+    int32_t maximized_w = 0, maximized_h = 0;
+    int32_t inset_w = 0, inset_h = 0;
     int i;
 
     memset(&found, 0, sizeof found);
@@ -348,6 +673,9 @@ static int ask_the_compositor(int32_t *pixels_w, int32_t *pixels_h,
 
     wl_display_roundtrip(display);      /* which globals there are */
     wl_display_roundtrip(display);      /* and what each display says */
+
+    if (want_work)
+        ask_for_maximized(display, &maximized_w, &maximized_h);
 
     wl_display_disconnect(display);
 
@@ -391,9 +719,43 @@ static int ask_the_compositor(int32_t *pixels_w, int32_t *pixels_h,
         return 0;
     }
 
-    *pixels_w = picked->width;
-    *pixels_h = picked->height;
-    *out_scale = picked->scale ? picked->scale : 1;
+    *pixels_w = picked->size.width;
+    *pixels_h = picked->size.height;
+    *out_scale = picked->size.scale ? picked->size.scale : 1;
+
+    if (maximized_w <= 0 || maximized_h <= 0)
+        return 1;               /* the display as it is, which is all there is */
+
+    /*
+     * Nobody named a display, so the maximised size is the answer as it
+     * stands - and the display it is about is the one the compositor puts a
+     * new window on, which is the one the emulator's windows are about to
+     * appear on as well. It is in the pixels a window is measured in, which
+     * is what a scale of one says here: the compositor has already divided by
+     * its own, that being what it did to arrive at the size it offered.
+     */
+    if (!(wanted && *wanted))
+    {
+        *pixels_w = maximized_w;
+        *pixels_h = maximized_h;
+        *out_scale = 1;
+
+        return 1;
+    }
+
+    /*
+     * Somebody did, and a window cannot be maximised onto a display of one's
+     * choosing: xdg-shell has set_fullscreen for a named display and nothing
+     * of the kind for maximising, so the window went wherever the compositor
+     * puts windows. What carries across is how much room the desktop took,
+     * which is the same panel on every display of a desk that has one, so
+     * that is what is worked out and taken off the display that was asked
+     * for.
+     */
+    inset_of_found(maximized_w, maximized_h, &inset_w, &inset_h);
+
+    *pixels_w -= inset_w * *out_scale;
+    *pixels_h -= inset_h * *out_scale;
 
     return 1;
 }
@@ -408,10 +770,10 @@ static int ask_the_compositor(int32_t *pixels_w, int32_t *pixels_h,
  * screen falls back to the one GEM applications were written for and the
  * planes stay as asked. See screen_mode below.
  */
-static int ask_the_compositor(int32_t *pixels_w, int32_t *pixels_h,
-                              int32_t *out_scale)
+static int ask_the_compositor(int want_work, int32_t *pixels_w,
+                              int32_t *pixels_h, int32_t *out_scale)
 {
-    (void)pixels_w; (void)pixels_h; (void)out_scale;
+    (void)want_work; (void)pixels_w; (void)pixels_h; (void)out_scale;
 
     return 0;
 }
@@ -426,18 +788,26 @@ static int ask_the_compositor(int32_t *pixels_w, int32_t *pixels_h,
  * know how large a surface to make - and a display is not unplugged in
  * between. Remembering the answer keeps the round trip the one round trip the
  * note above describes rather than one per caller.
+ *
+ * The one thing that makes it worth asking twice is a caller wanting the
+ * maximised size when the answer in hand was worked out without it. That
+ * cannot happen as things are - every caller in a run asks about the same
+ * screen - but an answer that is remembered has to say what question it
+ * answers, or the first caller decides for the rest.
  */
-static int ask_the_compositor_once(int32_t *pixels_w, int32_t *pixels_h,
-                                   int32_t *out_scale)
+static int ask_the_compositor_once(int want_work, int32_t *pixels_w,
+                                   int32_t *pixels_h, int32_t *out_scale)
 {
     static int asked;
+    static int asked_work;
     static int answered;
     static int32_t was_w, was_h, was_scale;
 
-    if (!asked)
+    if (!asked || (want_work && !asked_work))
     {
-        answered = ask_the_compositor(&was_w, &was_h, &was_scale);
+        answered = ask_the_compositor(want_work, &was_w, &was_h, &was_scale);
         asked = 1;
+        asked_work = want_work;
     }
 
     *pixels_w = was_w;
@@ -472,7 +842,8 @@ void screen_mode(int16_t *width, int16_t *height, int16_t *planes)
 
         *planes = native[i].planes;
 
-        if (ask_the_compositor_once(&pixels_w, &pixels_h, &out_scale))
+        if (ask_the_compositor_once(native[i].work, &pixels_w, &pixels_h,
+                                    &out_scale))
         {
             screen_from_display(pixels_w, pixels_h, out_scale, width, height);
             return;

--- a/src/screen.h
+++ b/src/screen.h
@@ -54,6 +54,30 @@ int screen_scale(void);
 void screen_from_display(int32_t pixels_w, int32_t pixels_h, int32_t out_scale,
                          int16_t *width, int16_t *height);
 
+/* One display as the compositor described it: the mode it is in, in its own
+ * pixels, and how many of those it shows a window's pixel in */
+struct screen_display {
+    int32_t width, height;
+    int32_t scale;
+};
+
+/*
+ * How much of a display the desktop keeps for itself, worked out backwards
+ * from how large a maximised window came out.
+ *
+ * There is no asking for this. Wayland tells a client how large the displays
+ * are and never what is on them, so a panel, a dock and a frame the desktop
+ * draws are all invisible until something is maximised and comes back smaller
+ * than the display it is on - and which display that was is not said either,
+ * so it is the one whose size the answer fits inside with the least left over.
+ *
+ * The maximised size is in the pixels a window is measured in; so is what
+ * comes back, and both are nought when nothing fits.
+ */
+void screen_inset(const struct screen_display *displays, int count,
+                  int32_t maximized_w, int32_t maximized_h,
+                  int32_t *inset_w, int32_t *inset_h);
+
 /* The smallest screen worth handing to GEM, which is the smallest one an
  * Atari had. Below this the AES's own dialogs have nowhere to go. */
 #define SCREEN_MIN_W (320)

--- a/src/screentest.c
+++ b/src/screentest.c
@@ -33,6 +33,11 @@
  * them they cover the things that are easy to get wrong: a scale the
  * compositor applies as well as the one the emulator does, and a width that
  * does not divide into sixteen.
+ *
+ * The same desk answers the other half of this, which is how much of a
+ * display a panel or a dock keeps - see insets below. That is worked out
+ * backwards from how large a maximised window came out, so what a test has to
+ * arrange is a size, and a size is the one thing it can.
  */
 
 #include "screen.h"
@@ -80,6 +85,69 @@ static void both(int scale, int32_t pw, int32_t ph, int32_t out_scale,
     check(w, want_w, name);
     snprintf(name, sizeof name, "%s is %d down", what, want_h);
     check(h, want_h, name);
+}
+
+/* The two displays above, described the way the compositor describes them */
+static const struct screen_display desk[] = {
+    { 3456, 2160, 2 },      /* 1728x1080 to lay a window out in */
+    { 3440, 1440, 1 },
+};
+
+/*
+ * How much of a display the desktop kept, worked out from how large a
+ * maximised window came out.
+ *
+ * Which display the window went to is not said, so the answer has to be found
+ * by fitting: it is the one the maximised size fits inside with the least
+ * left over. That is exact when there is one display and a guess when there
+ * are two the same, and a guess is what the whole business is - a panel is on
+ * every display of a desk that has one.
+ */
+static void insets(void)
+{
+    int32_t iw, ih;
+
+    /* The one in front of you, with a panel forty tall along the bottom */
+    screen_inset(desk, 2, 1728, 1040, &iw, &ih);
+    check(iw, 0, "a panel along the bottom takes nothing across");
+    check(ih, 40, "and forty down");
+
+    /* And a dock down the side of the other one as well */
+    screen_inset(desk, 2, 3372, 1400, &iw, &ih);
+    check(iw, 68, "a dock down the side takes its width across");
+    check(ih, 40, "and the panel is still there");
+
+    /* A desktop that keeps nothing, which is a window as large as the display
+     * and an inset of nothing */
+    screen_inset(desk, 2, 1728, 1080, &iw, &ih);
+    check(iw, 0, "a bare desktop keeps nothing across");
+    check(ih, 0, "and nothing down");
+
+    /* One display, which is the ordinary case and the one that is not a
+     * guess: there is nowhere else the window can have gone */
+    screen_inset(desk, 1, 1700, 1000, &iw, &ih);
+    check(iw, 28, "with one display the answer is arithmetic");
+    check(ih, 80, "in both directions");
+
+    /*
+     * A maximised size that fits inside neither, which is what a compositor
+     * scaling by something other than a whole number reports: wl_output says
+     * twice the pixels for a display shown at one and a half, so the display
+     * looks smaller than the window it just offered. Nothing is taken off,
+     * and the screen is the display as it was before any of this.
+     */
+    screen_inset(desk, 1, 2304, 1400, &iw, &ih);
+    check(iw, 0, "a window larger than every display leaves the display alone");
+    check(ih, 0, "in both directions");
+
+    /* And the answers that are not answers */
+    screen_inset(desk, 2, 0, 0, &iw, &ih);
+    check(iw, 0, "a maximised size of nothing is not an answer");
+    check(ih, 0, "in both directions");
+
+    screen_inset(desk, 0, 1728, 1040, &iw, &ih);
+    check(iw, 0, "and neither is a maximised size with no display to fit it");
+    check(ih, 0, "in both directions");
 }
 
 int main(void)
@@ -139,6 +207,8 @@ int main(void)
     check(w <= 32767 && w > 0, 1, "an enormous display is cut to a word");
     check(h <= 32767 && h > 0, 1, "in both directions");
     check(w % 16, 0, "and is still a whole number of words across");
+
+    insets();
 
     printf("1..%d\n", n);
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -346,13 +346,20 @@ check: all
 	  ! grep -q '^not ok' out || exit 1; \
 	  grep -q '^1\.\.' out || exit 1; \
 	done
-	# The two whose size is a rule rather than a number, with nothing to
+	# The four whose size is a rule rather than a number, with nothing to
 	# ask. A compositor is not something a test can arrange - this machine
 	# may have two displays and a build server none - so what is checked
 	# here is what they come to when there is none, and the arithmetic for
 	# when there is one is bin/screentest's to check. The planes are the
 	# half that holds either way, and they are what differs below.
-	for s in native-mono native-color; do \
+	#
+	# WAYLAND_DISPLAY is pointed at nothing for all four rather than left
+	# alone, because this is the one thing in the suite whose answer would
+	# otherwise be the display of whoever is running it. native-mono and
+	# native-color go further than the other two and ask how large a
+	# maximised window would be, so with a desktop in reach they would be
+	# that desktop's panel as well.
+	for s in native-mono native-color display-mono display-color; do \
 	  TOSEMU_SCREEN=$$s $(NO_DISPLAY) $(TOSEMU) test-c-screen $$s > out \
 	    || exit 1; \
 	  ! grep -q '^not ok' out || exit 1; \

--- a/tests/c-screen.c
+++ b/tests/c-screen.c
@@ -91,17 +91,22 @@ static const struct {
     { "tt-high",   1280, 960,   2, 8, 16, 278, 278, 19, 19 },
 
     /*
-     * And the two whose size is a rule rather than a number, as they come out
+     * And the four whose size is a rule rather than a number, as they come out
      * with no compositor to ask - which is every test run, and is why they can
      * be checked here at all. The size falls back to the one GEM applications
      * were written for; the planes are what was asked for either way, being
-     * the half of those two that does not depend on there being a display.
+     * the half of those four that does not depend on there being a display.
      *
-     * How large they are when there is one is arithmetic rather than a
-     * workstation, and bin/screentest checks that.
+     * With no display there is no difference between the pairs either: what
+     * separates them is how much of a display a panel keeps, and nothing
+     * keeps any of a display that is not there. How large they are when there
+     * is one is arithmetic rather than a workstation, and bin/screentest
+     * checks that.
      */
-    { "native-mono",  640, 400,  2, 8, 16, 372, 372, 19, 19 },
-    { "native-color", 640, 400, 16, 8, 16, 372, 372, 19, 19 },
+    { "native-mono",   640, 400,  2, 8, 16, 372, 372, 19, 19 },
+    { "native-color",  640, 400, 16, 8, 16, 372, 372, 19, 19 },
+    { "display-mono",  640, 400,  2, 8, 16, 372, 372, 19, 19 },
+    { "display-color", 640, 400, 16, 8, 16, 372, 372, 19, 19 },
 };
 
 int main(int argc, char **argv)


### PR DESCRIPTION
native-mono and native-color were worked out from the whole display, and a desktop keeps some of its display for itself. A panel across the bottom is invisible to a Wayland client, so the screen went behind it - and the corner that ends up under a panel is the one a GEM window keeps its size box in, which is a window that cannot be resized.

Wayland has no work area to ask for. What it has is maximising, which is the compositor being asked for the largest window it will give and answering with a size - the panel, the dock and any frame it draws itself, all subtracted by the only party that knows about them. So that is what is asked, on a surface committed with no buffer and destroyed as soon as the answer arrives: nothing is ever shown, and it costs a wait after the two round trips that were there already. A compositor that does not answer within a quarter of a second, or has no xdg-shell to answer with, leaves the screen as it was.

A window cannot be maximised onto a display of one's choosing, so when TOSEMU_OUTPUT names one it is how much room the desktop took that carries across rather than the size it left, that being the same panel on every display of a desk that has one. Without a name it is the display the compositor puts a new window on, which is where the emulator's windows are about to appear.

display-mono and display-color are the two as they were, the whole display regardless of what is on it. NO_WAYLAND=1 takes the asking out along with the rest of Wayland, and with nothing to ask all four still fall back to 640x400, which is what the suite pins.